### PR TITLE
refactor(ui): sendButton size, 아이콘 크기 추가 / 스토리북 수정

### DIFF
--- a/components/ui/Buttons/SendButton/index.stories.tsx
+++ b/components/ui/Buttons/SendButton/index.stories.tsx
@@ -8,6 +8,13 @@ const meta: Meta<typeof SendButton> = {
 	parameters: {
 		layout: "centered",
 	},
+	argTypes: {
+		sizes: {
+			control: "select",
+			options: ["small", "medium", "large"],
+			description: "버튼의 크기를 설정합니다.",
+		},
+	},
 };
 
 export default meta;
@@ -15,3 +22,21 @@ export default meta;
 type Story = StoryObj<typeof SendButton>;
 
 export const Default: Story = {};
+
+export const Small: Story = {
+	args: {
+		sizes: "small",
+	},
+};
+
+export const Medium: Story = {
+	args: {
+		sizes: "medium",
+	},
+};
+
+export const Large: Story = {
+	args: {
+		sizes: "large",
+	},
+};

--- a/components/ui/Buttons/SendButton/index.tsx
+++ b/components/ui/Buttons/SendButton/index.tsx
@@ -1,20 +1,43 @@
 import { Button } from "@headlessui/react";
 import { cn } from "@/utils/cn";
 import { IcBye } from "../../icons";
+import { cva, VariantProps } from "class-variance-authority";
+import { ButtonHTMLAttributes } from "react";
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-	className?: string;
+const sendButtonVariants = cva(
+	"flex cursor-not-allowed items-center justify-center rounded-full bg-white ring-1 ring-gray-200",
+	{
+		variants: {
+			sizes: {
+				small: "size-10",
+				medium: "size-12",
+				large: "size-15",
+			},
+		},
+		defaultVariants: {
+			sizes: "medium",
+		},
+	},
+);
+
+type SendButtonSizes = NonNullable<VariantProps<typeof sendButtonVariants>["sizes"]>;
+
+const ICON_SIZE_MAP: Record<SendButtonSizes, "sm" | "md" | "lg"> = {
+	small: "sm",
+	medium: "md",
+	large: "lg",
 };
 
-export default function SendButton({ className, ...props }: ButtonProps) {
+interface SendButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+	sizes?: SendButtonSizes;
+	className?: string;
+}
+
+export default function SendButton({ className, sizes = "medium", ...props }: SendButtonProps) {
+	const iconSize = ICON_SIZE_MAP[sizes];
 	return (
-		<Button
-			className={cn(
-				"flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white ring-1 ring-gray-200",
-				className,
-			)}
-			{...props}>
-			<IcBye />
+		<Button className={cn(sendButtonVariants({ sizes }), className)} {...props}>
+			<IcBye size={iconSize} />
 		</Button>
 	);
 }


### PR DESCRIPTION
resolves: #42

## 🛠️ 설명 (Description)

SendButton 컴포넌트에 sizes variant 및 아이콘 크기 추가 , cursor-not-allowed 추가

## 📝 변경 사항 요약 (Summary)

- sizes variant 추가 (small, medium, large)
- ICON_SIZE_MAP 추가하여 버튼 크기에 맞는 아이콘 크기 자동 적용
- 스토리북 추가

## 💁 변경 사항 이유 (Why)

-  모집 마감됐을 때 찜 버튼 대신 보여주는 용도버튼 대신 보여주는 용도로, 사용되는 위치에 따라 크기가 달라 지는 경우가 있어 size variant 추가 및 cursor-not-allowed 추가

## ✅ 테스트 계획 (Test Plan)

- 스토리북에서 small, medium, large 크기 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #42 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
- UtilityButton과 동일한 패턴으로 구현했습니다.
