### PR TITLE
fix(ui): 아이콘 컴포넌트에서 css 속성값 키워드 적용

### DIFF
--- a/utils/resolveIconAttr.ts
+++ b/utils/resolveIconAttr.ts
@@ -14,6 +14,7 @@ export interface IconProps extends React.SVGProps<SVGSVGElement> {
 	size?: Size;
 	isGradient?: boolean;
 }
+
 export const GRADIENT_MAP: Record<string, string> = {
 	// --gradient-purple-200-lr, --gradient-purple-200-rl, --gradient-purple-500
 	"purple-400": "purple-700",
@@ -30,6 +31,7 @@ const SIZE_MAP = {
 	xl: 40,
 	xxl: 42,
 } as const;
+
 type Color = string;
 type Size = keyof typeof SIZE_MAP | number | `${number}%` | `${number}px`;
 interface Props {
@@ -40,16 +42,16 @@ interface Props {
 	size: Size;
 }
 
-function resolveColor(value: Color | undefined): Color {
-	const CSS_KEYWORDS = new Set([
-		"currentColor",
-		"inherit",
-		"transparent",
-		"none",
-		"unset",
-		"initial",
-	]);
+const CSS_KEYWORDS = new Set([
+	"currentColor",
+	"inherit",
+	"transparent",
+	"none",
+	"unset",
+	"initial",
+]);
 
+function resolveColor(value: Color | undefined): Color {
 	if (!value) return "currentColor";
 	if (CSS_KEYWORDS.has(value) || value.startsWith("#") || value.startsWith("rgb")) {
 		return value;


### PR DESCRIPTION
## 🛠️ 설명 (Description)

아이콘 컴포넌트의 `color` prop에 CSS 속성값이 적용되도록 수정하였습니다.

## 📝 변경 사항 요약 (Summary)

- 값이 없는 경우(falsy 값을 직접 주입 시) `currentColor` 로 적용됩니다.
- 값이 아래와 같은 경우 바로 적용됩니다.
CSS 속성값, `#`나 `rgb` 로 시작하는 텍스트
- 그 외의 경우 css 변수로 판단되어 `--color` prefix 가 붙습니다.

## 💁 변경 사항 이유 (Why)

텍스트 색상과 아이콘 색상을 일치시켜야 하는 경우 문제가 발생하였습니다.
예제 코드는 다음과 같습니다.
```
 <div className="text-purple-600">
    텍스트
    <IcFilter color="currentColor" />
 </div>
```

## ✅ 테스트 계획 (Test Plan)

- 부모 영역에 `color` 값을 주고 아이콘 컴포넌트에 `color` prop 을 주어  테스트하였습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #55 
- Related #9 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.