### PR TITLE
design(ui): 모임 상세 정보 및 참여자 목록 UI 구현

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,6 +5,7 @@ const config: StorybookConfig = {
 		"../stories/**/*.mdx",
 		"../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
 		"../components/**/*.stories.@(js|jsx|msx|mjs|ts|tsx)",
+		"../features/**/*.stories.@(js|jsx|mjs|ts|tsx)",
 	],
 	addons: [
 		"@chromatic-com/storybook",

--- a/components/ui/Badges/index.stories.tsx
+++ b/components/ui/Badges/index.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { Badge } from "./index";
 import { StatusLabel } from "@/components/ui/StatusLabel";
-import { IcCheckCircle } from "@/components/ui/icons";
 
 const meta: Meta<typeof Badge> = {
 	title: "UI/Badge",

--- a/components/ui/Participants/index.tsx
+++ b/components/ui/Participants/index.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { Participant } from "@/components/ui/Containers/PersonnelContainer";
+import { Participant } from "@/features/Post/components/Containers/PersonnelContainer";
 
 // TODO: 추후 API 응답 타입으로 대체 예정
 

--- a/features/Post/components/Containers/InformationContainer/index.stories.tsx
+++ b/features/Post/components/Containers/InformationContainer/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import InformationContainer from "./index";
 
 const meta: Meta<typeof InformationContainer> = {
-	title: "ui/InformationContainer",
+	title: "POSTS/InformationContainer",
 	component: InformationContainer,
 	tags: ["autodocs"],
 	argTypes: {
@@ -20,12 +20,18 @@ export default meta;
 
 type Story = StoryObj<typeof InformationContainer>;
 
+const now = new Date();
+const meetingDate = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000).toISOString();
+const in12Hours = new Date(now.getTime() + 12 * 60 * 60 * 1000).toISOString();
+const in2Days = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000).toISOString();
+const past1Hour = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+
 const defaultArgs = {
 	name: "달램핏 모임",
 	type: "달램핏",
 	region: "건대입구",
-	dateTime: "2026-02-10T14:00:00.000Z",
-	registrationEnd: "2026-02-09T23:59:59.000Z",
+	dateTime: meetingDate,
+	registrationEnd: in12Hours,
 	capacity: 10,
 };
 
@@ -39,16 +45,35 @@ export const Host: Story = {
 	args: { ...defaultArgs, isHost: true },
 };
 
+export const DeadlineFar: Story = {
+	name: "N일 후 마감",
+	args: { ...defaultArgs, isHost: false, registrationEnd: in2Days },
+};
+
+export const DeadlineSoon: Story = {
+	name: "오늘 HH시 마감",
+	args: { ...defaultArgs, isHost: false, registrationEnd: in12Hours },
+};
+
+export const Closed: Story = {
+	name: "모집 마감 (버튼 비활성화)",
+	args: { ...defaultArgs, isHost: false, registrationEnd: past1Hour },
+};
+
 export const LongTitle: Story = {
+	name: "긴 제목",
 	args: {
 		...defaultArgs,
+		isHost: false,
 		name: "제목이 아주 길어질 경우 말줄임표로 처리되는지 확인하는 모임입니다",
 	},
 };
 
 export const DifferentRegion: Story = {
+	name: "다른 지역/타입",
 	args: {
 		...defaultArgs,
+		isHost: false,
 		name: "홍대 독서 모임",
 		type: "독서",
 		region: "홍대입구",

--- a/features/Post/components/Containers/InformationContainer/index.tsx
+++ b/features/Post/components/Containers/InformationContainer/index.tsx
@@ -6,7 +6,13 @@ import { IcCrownOutline, IcLocation } from "@/components/ui/icons";
 import Button from "@/components/ui/Buttons/Button";
 import UtilityButton from "@/components/ui/Buttons/UtilityButton";
 import ActionDropdown from "@/components/ui/Dropdowns/ActionDropdown";
-import { uiFormatDate, uiFormatDeadline, uiFormatTime } from "@/utils/date";
+import { useState } from "react";
+import {
+	isDeadlinePassed,
+	uiFormatDate,
+	uiFormatDeadline,
+	uiFormatTime,
+} from "@/features/Post/utills";
 
 interface InformationContainerProps {
 	name: string;
@@ -15,7 +21,6 @@ interface InformationContainerProps {
 	dateTime: string;
 	registrationEnd: string;
 	capacity: number;
-	// TODO: 추후 hostId와 currentUserId 비교로 변경 예정
 	isHost: boolean;
 }
 
@@ -27,6 +32,17 @@ export default function InformationContainer({
 	registrationEnd,
 	isHost,
 }: InformationContainerProps) {
+	const [isJoined, setIsJoined] = useState(false);
+	const isClosed = isDeadlinePassed(registrationEnd);
+
+	const handleJoinClick = () => {
+		setIsJoined((prev) => !prev);
+	};
+
+	const handleShareClick = () => {
+		navigator.clipboard.writeText(window.location.href);
+	};
+
 	const actionItems = [
 		{
 			label: "수정하기",
@@ -41,11 +57,19 @@ export default function InformationContainer({
 	return (
 		<div className="flex h-50 w-85.75 flex-col gap-7 rounded-[20px] bg-white px-6 pt-5 pb-6 lg:h-70.5 lg:w-157.5 lg:gap-10 lg:rounded-4xl lg:px-10 lg:pt-8.5 lg:pb-8">
 			<div className="flex w-full flex-col gap-4 lg:gap-6">
-				<div className={`flex w-full items-center gap-2 ${isHost && "justify-between"}`}>
+				<div className={`flex w-full items-center gap-2 ${isHost ? "justify-between" : ""}`}>
 					<div className="flex items-center gap-2">
-						<DeadlineTag>오늘 {uiFormatDeadline(registrationEnd)} 마감</DeadlineTag>
-						<TimeTag>{uiFormatDate(dateTime)}</TimeTag>
-						<TimeTag>{uiFormatTime(dateTime)}</TimeTag>
+						{!isClosed && (
+							<DeadlineTag size="sm" className="md:h-6 md:text-sm">
+								{uiFormatDeadline(registrationEnd)}
+							</DeadlineTag>
+						)}
+						<TimeTag size="sm" className="md:h-6 md:text-sm">
+							{uiFormatDate(dateTime)}
+						</TimeTag>
+						<TimeTag size="sm" className="md:h-6 md:text-sm">
+							{uiFormatTime(dateTime)}
+						</TimeTag>
 					</div>
 					{isHost && <ActionDropdown items={actionItems} />}
 				</div>
@@ -69,9 +93,11 @@ export default function InformationContainer({
 				<UtilityButton sizes="small" className="lg:size-15" />
 				<Button
 					sizes="small"
-					colors="purple"
+					colors={isJoined ? "purpleBorder" : "purple"}
+					disabled={!isHost && isClosed}
+					onClick={isHost ? handleShareClick : handleJoinClick}
 					className="flex-1 lg:h-15 lg:rounded-2xl lg:px-7.5 lg:text-xl">
-					{isHost ? "공유하기" : "참여하기"}
+					{isHost ? "공유하기" : isJoined ? "참여 취소하기" : "참여하기"}
 				</Button>
 			</div>
 		</div>

--- a/features/Post/components/Containers/PersonnelContainer/index.stories.tsx
+++ b/features/Post/components/Containers/PersonnelContainer/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import PersonnelContainer from "./index";
 
 const meta: Meta<typeof PersonnelContainer> = {
-	title: "ui/PersonnelContainer",
+	title: "POSTS/PersonnelContainer",
 	component: PersonnelContainer,
 	tags: ["autodocs"],
 	argTypes: {

--- a/features/Post/components/Containers/PersonnelContainer/index.tsx
+++ b/features/Post/components/Containers/PersonnelContainer/index.tsx
@@ -25,7 +25,7 @@ export default function PersonnelContainer({
 	participants,
 }: PersonnelProps) {
 	return (
-		<div className="flex h-28.75 w-85.75 flex-col gap-2 rounded-[5px] bg-linear-to-r from-purple-100 to-purple-200 px-6 py-6 pt-5 pb-5.5 lg:h-35.25 lg:w-157.5 lg:rounded-[28px] lg:px-10 lg:py-10 lg:pt-7 lg:pb-8.5">
+		<div className="flex h-28.75 w-85.75 flex-col gap-2 rounded-[20px] bg-linear-to-r from-purple-100 to-purple-200 px-6 py-6 pt-5 pb-5.5 lg:h-35.25 lg:w-157.5 lg:rounded-[28px] lg:px-10 lg:py-10 lg:pt-7 lg:pb-8.5">
 			<div className="flex flex-col gap-3 lg:gap-4">
 				<div className="flex items-center justify-between">
 					<div className="flex items-center gap-3">
@@ -36,7 +36,9 @@ export default function PersonnelContainer({
 						{/* TODO: 추후, API 응답으로 이미지 리스트 구현 예정 */}
 						<Participants participants={participants} />
 					</div>
-					<StatusLabel>개설확정</StatusLabel>
+					<StatusLabel size="sm" className="h-6 lg:text-sm">
+						개설확정
+					</StatusLabel>
 				</div>
 
 				<div className="flex flex-col gap-2">

--- a/features/Post/utills.ts
+++ b/features/Post/utills.ts
@@ -1,0 +1,37 @@
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export const KOREAN_TIMEZONE = "Asia/Seoul";
+
+// UI 표시용 "M월 D일"
+export const uiFormatDate = (date: string | Date) => {
+	return dayjs(date).tz(KOREAN_TIMEZONE).format("M월 D일");
+};
+
+// UI 표시용 "HH:mm"
+export const uiFormatTime = (date: string | Date) => {
+	return dayjs(date).tz(KOREAN_TIMEZONE).format("HH:mm");
+};
+
+// UI 표시용 "HH시"
+export const uiFormatDeadline = (date: string | Date) => {
+	const deadline = dayjs(date).tz(KOREAN_TIMEZONE);
+	const now = dayjs().tz(KOREAN_TIMEZONE);
+	const diffHours = deadline.diff(now, "hour");
+
+	if (diffHours >= 24) {
+		const diffDays = deadline.diff(now, "day");
+		return `${diffDays}일 후 마감`;
+	}
+
+	return deadline.format("오늘 HH시 마감");
+};
+
+// 마감 기간 여부
+export const isDeadlinePassed = (date: string | Date): boolean => {
+	return dayjs().tz(KOREAN_TIMEZONE).isAfter(dayjs(date).tz(KOREAN_TIMEZONE));
+};

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -24,18 +24,3 @@ export const parseDateString = (value?: string) => {
 
 	return parsed.toDate();
 };
-
-// UI 표시용 "M월 D일"
-export const uiFormatDate = (date: string | Date) => {
-	return dayjs(date).tz(KOREAN_TIMEZONE).format("M월 D일");
-};
-
-// UI 표시용 "HH:mm"
-export const uiFormatTime = (date: string | Date) => {
-	return dayjs(date).tz(KOREAN_TIMEZONE).format("HH:mm");
-};
-
-// UI 표시용 "HH시"
-export const uiFormatDeadline = (date: string | Date) => {
-	return dayjs(date).tz(KOREAN_TIMEZONE).format("HH시");
-};


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 상세 페이지 구성을 위한 핵심 정보 컨테이너 2종(`InformationContainer`, `PersonnelContainer`)와
참여자 목록을 시각화하는 `Participants` 컴포넌트를 구현했습니다.

## 📄 설계 문서 (Design Document)

피그마 참고

## 📝 변경 사항 요약 (Summary)

- `PersonnelContainer` 구현: 모임 정원 및 현재 참여 인원을 `ProgressBar`와 함께 시각화.
- `InformationContainer` 구현: 모임 이름, 지역, 타입, 마감 기한 등 상세 정보 노출 및 호스트 여부에 따른 액션 분기
- `Participants` 컴포넌트 구현: 아바타 스택 UI를 통해 참여자 프로필 노출 및 최대 표시 인원 초과 시 카운트(+n) 로직 적용.

## 💁 변경 사항 이유 (Why)

- 사용자가 모임의 핵심 정보(참여 인원, 마감 기한 등)를 한눈에 파악할 수 있도록 직관적인 UI가 필요함.
- 호스트와 일반 사용자의 권한 차이를 버튼 및 드롭다운 메뉴를 통해 명확히 구분하기 위함.

## ✅ 테스트 계획 (Test Plan)

- `isHost` Prop 변경 시 버튼 텍스트 및 드롭다운 노출 여부 확인.

## 🔗 관련 이슈 (Related Issues)

- Closed #48

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)

`DeadlineTag` & `TimeTag`가 현재, `size`를 css 속성으로 적용하여, 현재 맞지 않는 규격을 가지고 있습니다. 이에 따라, 해당 css 속성에서, `size` props를 사용하도록 개선할 예정입니다.