### PR TITLE
chore(config): storybook 타입 옵션 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,5 +15,8 @@ const config: StorybookConfig = {
 	],
 	framework: "@storybook/nextjs-vite",
 	staticDirs: ["../public"],
+	typescript: {
+		reactDocgen: "react-docgen-typescript",
+	},
 };
 export default config;


### PR DESCRIPTION
## 🛠️ 설명 (Description)

스토리북 .storybook/main.ts 에 추가 옵션을 설정하였습니다.

## 📝 변경 사항 요약 (Summary)

- .storybook/main.ts
```
typescript: {
	reactDocgen: "react-docgen-typescript",
},
```

## 💁 변경 사항 이유 (Why)

하위 컴포넌트 추가 시(`subcomponents`) prop 타입이 제대로 반영되지 않아 문제를 수정하였습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #62 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 변경 사항에 대한 문서화가 완료되었습니다.
