### PR TITLE
refactor(tag): tag / Status Label 컴포넌트 개선

### DIFF
--- a/components/ui/StatusLabel/index.stories.tsx
+++ b/components/ui/StatusLabel/index.stories.tsx
@@ -8,11 +8,11 @@ const meta: Meta<typeof StatusLabel> = {
 	argTypes: {
 		size: {
 			control: "select",
-			options: ["sm", "md", "lg"],
+			options: ["sm", "md"],
 		},
 		iconSize: {
 			control: "select",
-			options: ["xs", "sm", "md"],
+			options: ["xs", "sm"],
 		},
 	},
 	parameters: {

--- a/components/ui/StatusLabel/index.tsx
+++ b/components/ui/StatusLabel/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/utils/cn";
 import { IcCheckCircle } from "@/components/ui/icons";
 
-type StatusLabelSize = "sm" | "md" | "lg";
+type StatusLabelSize = "sm" | "md";
 
 interface StatusLabelProps {
 	children: React.ReactNode;
@@ -13,13 +13,11 @@ interface StatusLabelProps {
 const sizeVariants: Record<StatusLabelSize, string> = {
 	sm: "h-4.5 text-xs",
 	md: "h-6 text-sm",
-	lg: "h-6 text-sm",
 };
 
 const iconSizeMap: Record<StatusLabelSize, "xs" | "sm"> = {
 	sm: "xs",
 	md: "sm",
-	lg: "sm",
 };
 
 export function StatusLabel({ children, size = "sm", iconSize, className }: StatusLabelProps) {

--- a/components/ui/Tags/DeadlineTag/index.stories.tsx
+++ b/components/ui/Tags/DeadlineTag/index.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof DeadlineTag> = {
 	argTypes: {
 		size: {
 			control: "select",
-			options: ["sm", "md", "lg"],
+			options: ["sm", "md"],
 		},
 		iconSize: {
 			control: "select",

--- a/components/ui/Tags/DeadlineTag/index.tsx
+++ b/components/ui/Tags/DeadlineTag/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/utils/cn";
 import { IcAlarm } from "@/components/ui/icons";
 
-type DeadlineTagSize = "sm" | "md" | "lg";
+type DeadlineTagSize = "sm" | "md";
 
 interface DeadlineTagProps {
 	children: React.ReactNode;
@@ -13,13 +13,11 @@ interface DeadlineTagProps {
 const sizeVariants: Record<DeadlineTagSize, string> = {
 	sm: "h-5 rounded-md text-xs",
 	md: "h-6 rounded-lg text-sm",
-	lg: "h-6 rounded-lg text-sm",
 };
 
 const iconSizeMap: Record<DeadlineTagSize, "sm" | "md"> = {
 	sm: "sm",
 	md: "md",
-	lg: "md",
 };
 
 export function DeadlineTag({ children, size = "sm", iconSize, className }: DeadlineTagProps) {

--- a/components/ui/Tags/TimeTag/index.stories.tsx
+++ b/components/ui/Tags/TimeTag/index.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof TimeTag> = {
 	argTypes: {
 		size: {
 			control: "select",
-			options: ["sm", "md", "lg"],
+			options: ["sm", "md"],
 		},
 	},
 	parameters: {

--- a/components/ui/Tags/TimeTag/index.tsx
+++ b/components/ui/Tags/TimeTag/index.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/utils/cn";
 
-type TimeTagSize = "sm" | "md" | "lg";
+type TimeTagSize = "sm" | "md";
 
 interface TimeTagProps {
 	children: React.ReactNode;
@@ -11,7 +11,6 @@ interface TimeTagProps {
 const sizeVariants: Record<TimeTagSize, string> = {
 	sm: "h-5 rounded-md text-xs",
 	md: "h-6 rounded-lg text-sm",
-	lg: "h-6 rounded-lg text-sm",
 };
 
 export function TimeTag({ children, size = "sm", className }: TimeTagProps) {


### PR DESCRIPTION
## 🛠️ 설명 (Description)

Tag(`DeadlineTag`, `TimeTag`) 및 `StatusLabel` 컴포넌트 사이즈 처리 방식을 개선했습니다.

기존에는 내부 CSS 및 `breakpoint` 기반으로 사이즈가 결정되었으나,
이를 제거하고 `size` 및 `iconSize`를 props로 분리하여 명시적으로 제어 가능하도록 리팩토링했습니다.

또한 Storybook Controls를 통해 size 변경을 실시간으로 확인할 수 있도록 구성했습니다.

## 📄 설계 문서 (Design Document)

## 📝 변경 사항 요약 (Summary)

- `DeadlineTag`
  - `size (sm | md | lg)` prop 추가
  - `iconSize` prop 추가
  - 내부 `breakpoint` 제거
- `TimeTag`
  - `size (sm | md | lg)` prop 추가
  - 내부 `breakpoint` 제거
- `StatusLabel`
  - `size (sm | md | lg)` prop 추가
  - `iconSize` prop 추가
  - 내부 `breakpoint` 제거
- 공통
  - 사이즈를 CSS → props 기반으로 전환
  - Storybook Controls에서 `size` 변경 가능하도록 설정

## 💁 변경 사항 이유 (Why)

- 컴포넌트 재사용성 향상
- 반응형 `breakPoint` 의존 제거
- 디자인 시스템 일관성 강화

## ✅ 테스트 계획 (Test Plan)

- Storybook에서 `size` 변경 테스트

## 🔗 관련 이슈 (Related Issues)

- Closed #65 
- Related #8 #48 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

- 해당 PR이 머지된 후, #48  코드리뷰와 동시에 같이 적용할 예정입니다.
