### PR TITLE
feat(meetupDetail): 참가자 목록 펼치기 기능 구현

### DIFF
--- a/components/ui/Participants/index.tsx
+++ b/components/ui/Participants/index.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { Participant } from "@/features/meetupDetail/types";
 import Avatar from "@/components/ui/Avatar";
 
@@ -5,15 +8,18 @@ interface ParticipantsImageProps {
 	participants: Participant[];
 }
 
-const MAX_VISIBLE = 5;
+const MAX_VISIBLE = 4;
 
 export function Participants({ participants }: ParticipantsImageProps) {
-	const visibleParticipants = participants.slice(0, MAX_VISIBLE - 1);
-	const overCount = participants.length - (MAX_VISIBLE - 1);
-	const showOverCount = participants.length >= MAX_VISIBLE;
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	const visibleParticipants = isExpanded ? participants : participants.slice(0, MAX_VISIBLE);
+
+	const overCount = participants.length - MAX_VISIBLE;
+	const showOverCount = !isExpanded && overCount > 0;
 
 	return (
-		<div className="flex items-center -space-x-2">
+		<div className="flex items-center -space-x-2 overflow-x-auto">
 			{visibleParticipants.map((participant) => (
 				<Avatar
 					key={participant.id}
@@ -24,11 +30,21 @@ export function Participants({ participants }: ParticipantsImageProps) {
 					className="shrink-0"
 				/>
 			))}
-
 			{showOverCount && (
-				<div className="flex h-7.25 w-7.25 shrink-0 items-center justify-center rounded-full bg-white text-xs text-gray-700">
+				<button
+					type="button"
+					onClick={() => setIsExpanded(true)}
+					className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full bg-white text-xs text-gray-700 hover:bg-gray-100">
 					+{overCount}
-				</div>
+				</button>
+			)}
+			{isExpanded && (
+				<button
+					type="button"
+					onClick={() => setIsExpanded(false)}
+					className="ml-3 shrink-0 text-xs whitespace-nowrap text-gray-500 hover:text-gray-700">
+					접기
+				</button>
 			)}
 		</div>
 	);


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 상세 페이지 참가자 목록 UI를 개선합니다.

## 📄 설계 문서 (Design Document)

## 📝 변경 사항 요약 (Summary)

- `+N` 버튼 클릭 시, 전체 참가자 목록 펼치기 / 접기 기능 추가 

## 💁 변경 사항 이유 (Why)

- 참가자 5명 이상일 때, 나머지 참가자를 확인할 수 없는 문제점 개선

## ✅ 테스트 계획 (Test Plan)

- 참가자 5명 이상일 시, 정상 동작하는지 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #209 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
