### PR TITLE
#fix(meetup): 모임 찾기에서 참여 관련 이슈 수정

### DIFF
--- a/components/ui/GroupCard/index.tsx
+++ b/components/ui/GroupCard/index.tsx
@@ -23,6 +23,8 @@ interface GroupCardStatus {
 	isLiked: boolean;
 	/** 사용자의 참여 여부 */
 	isJoined: boolean;
+	/** 모임 완료 여부 */
+	isCompleted?: boolean;
 }
 interface GroupCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "id"> {
 	/** 모임 ID */
@@ -38,6 +40,7 @@ interface GroupCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "id"
 }
 type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
+// TODO: 리팩토링 시 status 값 제거
 function GroupCard({ id, href, status, children, className, ...props }: GroupCardProps) {
 	return (
 		<GroupCardContext.Provider value={status}>
@@ -207,7 +210,7 @@ interface ButtonProp extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	isPending?: boolean;
 }
 function JoinButton({ onClick, isPending, ...props }: ButtonProp) {
-	const { isRegClosed, isJoined } = useGroupCard();
+	const { isRegClosed, isJoined, isCompleted } = useGroupCard();
 
 	function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
 		e.preventDefault();
@@ -217,7 +220,7 @@ function JoinButton({ onClick, isPending, ...props }: ButtonProp) {
 
 	return (
 		<Button
-			disabled={!isJoined && isRegClosed}
+			disabled={(!isJoined && isRegClosed) || isCompleted}
 			colors="purpleBorder"
 			className="relative z-2 mt-auto h-10 w-20 text-sm font-semibold [grid-area:join-button] md:h-12 md:w-[103px] md:text-base"
 			onClick={handleClick}
@@ -229,7 +232,7 @@ function JoinButton({ onClick, isPending, ...props }: ButtonProp) {
 }
 
 function LikeButton({ onClick, isPending, ...props }: ButtonProp) {
-	const { isRegClosed, isLiked } = useGroupCard();
+	const { isRegClosed, isLiked, isCompleted } = useGroupCard();
 
 	function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
 		e.preventDefault();
@@ -238,7 +241,7 @@ function LikeButton({ onClick, isPending, ...props }: ButtonProp) {
 	}
 
 	// SendButton 은 모임 마감 여부 표시, 클릭 이벤트 없음
-	return !isRegClosed ? (
+	return !isRegClosed && !isCompleted ? (
 		<UtilityButton
 			pressed={isLiked}
 			className={likeButtonStyle}

--- a/features/meetup/list/components/MeetupCard.tsx
+++ b/features/meetup/list/components/MeetupCard.tsx
@@ -21,6 +21,7 @@ export default function MeetupCard({ data, setSelectedData, openModalFn }: Meetu
 		isRegClosed: checkIsRegClosed(data.registrationEnd, data.participantCount, data.capacity),
 		isLiked: data.isFavorited,
 		isJoined: data.isJoined,
+		isCompleted: data.isCompleted,
 	};
 	const href = `/meetup/${data.id}`;
 

--- a/features/meetup/list/hooks.ts
+++ b/features/meetup/list/hooks.ts
@@ -52,13 +52,16 @@ export function useMeetupToggle(meetingId: number, field: "isJoined" | "isFavori
 		queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list }); // 모임 목록
 		queryClient.invalidateQueries({ queryKey: meetupDetailQueryKeys.meeting(meetingId) }); // 해당 모임 상세
 		queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups }); // 참여한 모임 목록
-		queryClient.invalidateQueries({ queryKey: mypageQueryKeys.created }); // 만든 모임 목록
+		queryClient.invalidateQueries({ queryKey: mypageQueryKeys.created }); // 만든 모임 목록(주최자)
 
 		if (field === "isFavorited") {
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.favorites }); // 찜 개수
 		}
 		if (field === "isJoined") {
 			queryClient.invalidateQueries({ queryKey: meetupDetailQueryKeys.participants(meetingId) }); // 해당 모임 참여자
+			// 참여 가능 인원이 초과되어 해당 모임이 확정되는 경우
+			queryClient.invalidateQueries({ queryKey: headerQueryKeys.notifications }); // 알림 목록
+			queryClient.invalidateQueries({ queryKey: headerQueryKeys.notificationsCount }); // 알림 개수
 		}
 	}
 


### PR DESCRIPTION
## 🛠️ 설명 (Description)

1. 모임 찾기에서 사용자가 참여한 직후 모임이 확정되었을 때 알림이 오지 않는 이슈 수정
2. 모임 카드에서 `isCompleted` 가 누락되어 종료된 모임의 참여하기 버튼이 활성화되는 이슈 수정

## 📝 변경 사항 요약 (Summary)

- 모임 찾기에서 모임 참여 시 invalidate 알림 queryKey 추가
```
// 참여 가능 인원이 초과되어 해당 모임이 확정되는 경우
queryClient.invalidateQueries({ queryKey: headerQueryKeys.notifications }); // 알림 목록
queryClient.invalidateQueries({ queryKey: headerQueryKeys.notificationsCount }); // 알림 개수
```

- `groupCard` 의 status prop에 `isCompleted` 추가 및 버튼 표시 조건 수정

```
// 참여 버튼 비활성화(disabled)
disabled={(!isJoined && isRegClosed) || isCompleted}
// 찜하기 버튼 표시
!isRegClosed && !isCompleted
```

## 💁 변경 사항 이유 (Why)

- 치명적인 UX 이슈이기 때문에 수정 필요

## ✅ 테스트 계획 (Test Plan)

- 수동 테스트를 진행하였습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #224
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## ➕ 추가 정보 (Additional Information)

GroupCard 컴포넌트에서 `status` prop 을 제거하고 응답데이터를 받도록 리팩토링 예정입니다.