### PR TITLE
refactor(datefilter): 단일 날짜 데이터 형식에서 범위 날짜 형식으로 변경

### DIFF
--- a/components/ui/Filter/DateFilter/index.stories.tsx
+++ b/components/ui/Filter/DateFilter/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { useState } from "react";
-import DateFilter from ".";
+import { useMemo, useState } from "react";
+import DateFilter, { DateFilterValue } from ".";
 
 const meta: Meta<typeof DateFilter> = {
 	title: "Filters/DateFilter",
@@ -15,20 +15,72 @@ export default meta;
 
 type Story = StoryObj<typeof DateFilter>;
 
-function ControlledDateFilter() {
-	const [date, setDate] = useState("");
+function ValueViewer({ value }: { value: DateFilterValue }) {
+	const label = useMemo(() => {
+		if (!value.from && !value.to) return "선택된 값 없음";
+
+		if (value.from === value.to) {
+			return value.from;
+		}
+
+		return `${value.from || "-"} ~ ${value.to || "-"}`;
+	}, [value]);
+
+	return (
+		<div className="mt-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+			<p className="text-sm font-semibold text-gray-900">현재 전달되는 value</p>
+			<p className="mt-2 text-sm text-gray-700">{label}</p>
+			<pre className="mt-3 overflow-x-auto rounded-lg bg-gray-100 p-3 text-xs text-gray-800">
+				{JSON.stringify(value, null, 2)}
+			</pre>
+		</div>
+	);
+}
+
+function ControlledDateFilter({
+	initialValue = { from: "", to: "" },
+}: {
+	initialValue?: DateFilterValue;
+}) {
+	const [date, setDate] = useState<DateFilterValue>(initialValue);
 
 	return (
 		<div className="min-h-screen bg-gray-100">
 			<div className="mx-auto w-full max-w-7xl px-4 py-20 md:px-6">
-				<div className="flex justify-start">
-					<DateFilter value={date} onChange={setDate} />
+				<div className="space-y-6">
+					<div className="flex justify-start">
+						<DateFilter value={date} onChange={setDate} />
+					</div>
+
+					<ValueViewer value={date} />
 				</div>
 			</div>
 		</div>
 	);
 }
 
-export const Default: Story = {
+export const EmptyInitialValue: Story = {
 	render: () => <ControlledDateFilter />,
+};
+
+export const WithSingleDate: Story = {
+	render: () => (
+		<ControlledDateFilter
+			initialValue={{
+				from: "2026-04-06",
+				to: "2026-04-06",
+			}}
+		/>
+	),
+};
+
+export const WithRangeDate: Story = {
+	render: () => (
+		<ControlledDateFilter
+			initialValue={{
+				from: "2026-04-01",
+				to: "2026-04-05",
+			}}
+		/>
+	),
 };

--- a/components/ui/Filter/DateFilter/index.tsx
+++ b/components/ui/Filter/DateFilter/index.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { type DateRange } from "react-day-picker";
-import { getKoreanToday } from "@/utils/date";
+import { formatDateString, getKoreanToday, parseDateString } from "@/utils/date";
 import Calendar from "@/components/ui/Pickers/DatePicker/Calendar";
 import IcChevronDown from "@/components/ui/icons/IcChevronDown";
 import Button from "@/components/ui/Buttons/Button";
@@ -40,21 +40,13 @@ function formatDisplayRange(range?: DateRange) {
 	return `${from} ~ ${to}`;
 }
 
-function formatDate(date: Date) {
-	const year = date.getFullYear();
-	const month = String(date.getMonth() + 1).padStart(2, "0");
-	const day = String(date.getDate()).padStart(2, "0");
-
-	return `${year}-${month}-${day}`;
-}
-
 function formatDateRangeValue(range?: DateRange): DateFilterValue {
 	if (!range?.from) {
 		return { from: "", to: "" };
 	}
 
-	const from = formatDate(range.from);
-	const to = formatDate(range.to ?? range.from);
+	const from = formatDateString(range.from);
+	const to = formatDateString(range.to ?? range.from);
 
 	return { from, to };
 }
@@ -62,11 +54,11 @@ function formatDateRangeValue(range?: DateRange): DateFilterValue {
 function parseDateRangeValue(value: DateFilterValue): DateRange | undefined {
 	if (!value.from) return undefined;
 
-	const fromDate = new Date(value.from);
-	const toDate = value.to ? new Date(value.to) : undefined;
+	const fromDate = parseDateString(value.from);
+	const toDate = value.to ? parseDateString(value.to) : undefined;
 
-	if (Number.isNaN(fromDate.getTime())) return undefined;
-	if (toDate && Number.isNaN(toDate.getTime())) return undefined;
+	if (!fromDate) return undefined;
+	if (value.to && !toDate) return undefined;
 
 	return {
 		from: fromDate,
@@ -79,6 +71,10 @@ export default function DateFilter({ value = { from: "", to: "" }, onChange }: D
 	const isLg = useIsLg();
 	const parsedRange = parseDateRangeValue(value);
 	const [draftRange, setDraftRange] = useState<DateRange | undefined>(parsedRange);
+
+	useEffect(() => {
+		setDraftRange(parsedRange);
+	}, [value.from, value.to, parsedRange]);
 
 	return (
 		<Popover className="relative">

--- a/components/ui/Filter/DateFilter/index.tsx
+++ b/components/ui/Filter/DateFilter/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type DateRange } from "react-day-picker";
 import { formatDateString, getKoreanToday, parseDateString } from "@/utils/date";
 import Calendar from "@/components/ui/Pickers/DatePicker/Calendar";
@@ -69,12 +69,12 @@ function parseDateRangeValue(value: DateFilterValue): DateRange | undefined {
 export default function DateFilter({ value = { from: "", to: "" }, onChange }: DateFilterProps) {
 	const [month, setMonth] = useState<Date>(getKoreanToday());
 	const isLg = useIsLg();
-	const parsedRange = parseDateRangeValue(value);
+	const parsedRange = useMemo(() => parseDateRangeValue(value), [value.from, value.to]);
 	const [draftRange, setDraftRange] = useState<DateRange | undefined>(parsedRange);
 
 	useEffect(() => {
 		setDraftRange(parsedRange);
-	}, [value.from, value.to, parsedRange]);
+	}, [parsedRange]);
 
 	return (
 		<Popover className="relative">

--- a/components/ui/Filter/DateFilter/index.tsx
+++ b/components/ui/Filter/DateFilter/index.tsx
@@ -2,36 +2,91 @@
 
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { useState } from "react";
-import { formatDateString, getKoreanToday, parseDateString } from "@/utils/date";
+import { type DateRange } from "react-day-picker";
+import { getKoreanToday } from "@/utils/date";
 import Calendar from "@/components/ui/Pickers/DatePicker/Calendar";
 import IcChevronDown from "@/components/ui/icons/IcChevronDown";
 import Button from "@/components/ui/Buttons/Button";
 import FilterTrigger from "@/components/ui/Filter/FilterTrigger";
-import { useIsMd } from "@/hooks/useIsMd";
+import { useIsLg } from "@/hooks/useIsLg";
 import { cn } from "@/utils/cn";
 
+export type DateFilterValue = {
+	from: string;
+	to: string;
+};
+
 type DateFilterProps = {
-	value: string;
-	onChange: (value: string) => void;
+	value: DateFilterValue;
+	onChange: (value: DateFilterValue) => void;
 };
 
 function formatDisplayDate(date: Date) {
-	return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+	return `${date.getMonth() + 1}/${date.getDate()}`;
 }
 
-export default function DateFilter({ value = "", onChange }: DateFilterProps) {
+function formatDisplayRange(range?: DateRange) {
+	if (!range?.from) return "날짜 전체";
+	if (!range.to) return formatDisplayDate(range.from);
+
+	const from = formatDisplayDate(range.from);
+	const to = formatDisplayDate(range.to);
+
+	if (from === to) {
+		const [month, day] = from.split("/");
+		return `${month}월 ${day}일`;
+	}
+
+	return `${from} ~ ${to}`;
+}
+
+function formatDate(date: Date) {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+
+	return `${year}-${month}-${day}`;
+}
+
+function formatDateRangeValue(range?: DateRange): DateFilterValue {
+	if (!range?.from) {
+		return { from: "", to: "" };
+	}
+
+	const from = formatDate(range.from);
+	const to = formatDate(range.to ?? range.from);
+
+	return { from, to };
+}
+
+function parseDateRangeValue(value: DateFilterValue): DateRange | undefined {
+	if (!value.from) return undefined;
+
+	const fromDate = new Date(value.from);
+	const toDate = value.to ? new Date(value.to) : undefined;
+
+	if (Number.isNaN(fromDate.getTime())) return undefined;
+	if (toDate && Number.isNaN(toDate.getTime())) return undefined;
+
+	return {
+		from: fromDate,
+		to: toDate,
+	};
+}
+
+export default function DateFilter({ value = { from: "", to: "" }, onChange }: DateFilterProps) {
 	const [month, setMonth] = useState<Date>(getKoreanToday());
-	const isMd = useIsMd();
-	const parsed = parseDateString(value);
-	const [draftDate, setDraftDate] = useState<Date | undefined>(parsed || undefined); // 초기값으로 바로 설정
+	const isLg = useIsLg();
+	const parsedRange = parseDateRangeValue(value);
+	const [draftRange, setDraftRange] = useState<DateRange | undefined>(parsedRange);
 
 	return (
 		<Popover className="relative">
 			{({ close }) => (
 				<>
 					<PopoverButton as="div">
-						<FilterTrigger isActive={!!parsed}>
-							<span>{parsed ? formatDisplayDate(parsed) : "날짜 전체"}</span>
+						<FilterTrigger isActive={!!parsedRange?.from}>
+							<span>{formatDisplayRange(parsedRange)}</span>
 							<IcChevronDown className="h-4 w-4" />
 						</FilterTrigger>
 					</PopoverButton>
@@ -39,13 +94,14 @@ export default function DateFilter({ value = "", onChange }: DateFilterProps) {
 					<PopoverPanel
 						className={cn(
 							"absolute z-20 mt-2 w-74.5 rounded-xl border border-gray-200 bg-white p-6 shadow-xl",
-							isMd ? "left-0" : "right-0",
+							isLg ? "right-0" : "left-0",
 						)}>
 						<Calendar
+							mode="range"
 							month={month}
-							selectedDate={draftDate}
+							selectedDate={draftRange}
 							onMonthChange={setMonth}
-							onSelectDate={setDraftDate}
+							onSelectDate={setDraftRange}
 						/>
 
 						<div className="mt-3 grid grid-cols-2 gap-3">
@@ -53,9 +109,9 @@ export default function DateFilter({ value = "", onChange }: DateFilterProps) {
 								sizes="small"
 								colors="purpleBorder"
 								onClick={() => {
-									setDraftDate(undefined);
-									onChange(""); // 부모값 초기화
-									close(); // 패널 닫기
+									setDraftRange(undefined);
+									onChange({ from: "", to: "" });
+									close();
 								}}>
 								초기화
 							</Button>
@@ -63,7 +119,7 @@ export default function DateFilter({ value = "", onChange }: DateFilterProps) {
 							<Button
 								sizes="small"
 								onClick={() => {
-									onChange(draftDate ? formatDateString(draftDate) : "");
+									onChange(formatDateRangeValue(draftRange));
 									close();
 								}}>
 								적용

--- a/components/ui/Filter/FilterGroup/index.stories.tsx
+++ b/components/ui/Filter/FilterGroup/index.stories.tsx
@@ -19,7 +19,10 @@ type Story = StoryObj;
 
 function FilterGroup() {
 	// 날짜
-	const [date, setDate] = useState("");
+	const [date, setDate] = useState({
+		from: "",
+		to: "",
+	});
 
 	// 지역
 	const [region, setRegion] = useState<{

--- a/components/ui/Pickers/DatePicker/Calendar.tsx
+++ b/components/ui/Pickers/DatePicker/Calendar.tsx
@@ -1,76 +1,122 @@
 import { cn } from "@/utils/cn";
-import { DayPicker } from "react-day-picker";
+import { DayPicker, type DateRange } from "react-day-picker";
 import { ko } from "react-day-picker/locale";
 import { IcArrowRight } from "../../icons";
 
-type CalendarProps = {
+type BaseCalendarProps = {
 	month: Date;
-	selectedDate?: Date;
 	onMonthChange: (month: Date) => void;
+};
+
+type SingleCalendarProps = BaseCalendarProps & {
+	mode?: "single";
+	selectedDate?: Date;
 	onSelectDate: (date: Date | undefined) => void;
 };
 
-export default function Calendar({
-	month,
-	selectedDate,
-	onMonthChange,
-	onSelectDate,
-}: CalendarProps) {
+type RangeCalendarProps = BaseCalendarProps & {
+	mode: "range";
+	selectedDate?: DateRange;
+	onSelectDate: (date: DateRange | undefined) => void;
+};
+
+type CalendarProps = SingleCalendarProps | RangeCalendarProps;
+
+const calendarFormatters = {
+	formatCaption: (date: Date) => `${date.getFullYear()}년 ${date.getMonth() + 1}월`,
+};
+
+const calendarComponents = {
+	Chevron: ({
+		orientation,
+		className: iconClassName,
+	}: {
+		orientation?: "up" | "down" | "left" | "right";
+		className?: string;
+		size?: number;
+		disabled?: boolean;
+	}) => (
+		<IcArrowRight
+			size="md"
+			color="gray-800"
+			className={cn(orientation === "left" && "rotate-180", iconClassName)}
+		/>
+	),
+};
+
+export default function Calendar(props: CalendarProps) {
+	const isRangeMode = props.mode === "range";
+
+	const commonProps = {
+		locale: ko,
+		month: props.month,
+		onMonthChange: props.onMonthChange,
+		showOutsideDays: true,
+		fixedWeeks: true,
+		formatters: calendarFormatters,
+		components: calendarComponents,
+		className: "p-0",
+		classNames: {
+			root: "w-full",
+			months: "flex flex-col",
+			month: "p-0",
+			month_caption: "flex h-8 justify-center select-none",
+			caption: "relative flex h-20 items-center justify-center",
+			caption_label: "text-sm font-semibold text-gray-800",
+			nav: "contents",
+			button_previous:
+				"absolute top-8.5 left-7 -translate-y-1/2 cursor-pointer bg-transparent p-0 hover:bg-transparent",
+			button_next:
+				"absolute top-8.5 right-7 -translate-y-1/2 cursor-pointer bg-transparent p-0 hover:bg-transparent",
+			month_grid: "w-full border-collapse",
+			weekdays: "grid grid-cols-7",
+			weekday:
+				"flex h-8 items-center justify-center text-center text-sm font-semibold text-gray-600 select-none",
+			weeks: "flex flex-col gap-0",
+			week: "grid grid-cols-7",
+			day: "flex h-8 items-center justify-center p-0",
+			day_button: cn(
+				"relative z-10 flex h-8 w-8 items-center justify-center text-sm font-medium transition-colors focus:outline-none select-none",
+				isRangeMode
+					? "rounded-full text-gray-800 hover:bg-purple-100"
+					: "w-full rounded-lg text-gray-800 hover:bg-purple-100",
+			),
+
+			selected: isRangeMode
+				? ""
+				: "[&>button]:bg-purple-200 [&>button]:font-semibold [&>button]:text-purple-600",
+
+			range_start:
+				"rounded-l-2xl bg-purple-100 [&>button]:bg-purple-200 [&>button]:font-semibold [&>button]:text-purple-600",
+			range_middle:
+				"bg-purple-100 [&>button]:bg-transparent [&>button]:text-purple-600 [&>button]:rounded-none",
+			range_end:
+				"rounded-r-2xl bg-purple-100 [&>button]:bg-purple-200 [&>button]:font-semibold [&>button]:text-purple-600",
+
+			today: "[&>button]:text-purple-600",
+			outside: "[&>button]:text-gray-400",
+			disabled: "[&>button]:cursor-not-allowed [&>button]:text-gray-100",
+			hidden: "invisible",
+		},
+	};
+
+	if (props.mode === "range") {
+		return (
+			<DayPicker
+				{...commonProps}
+				mode="range"
+				selected={props.selectedDate}
+				onSelect={props.onSelectDate}
+			/>
+		);
+	}
+
 	return (
 		<DayPicker
+			{...commonProps}
 			mode="single"
-			locale={ko}
-			month={month}
-			selected={selectedDate}
-			onMonthChange={onMonthChange}
-			showOutsideDays
-			fixedWeeks
-			onSelect={onSelectDate}
-			formatters={{
-				formatCaption: (date) => `${date.getFullYear()}년 ${date.getMonth() + 1}월`,
-			}}
-			components={{
-				Chevron: ({ orientation, className: iconClassName }) => (
-					<IcArrowRight
-						size="md"
-						color="gray-800"
-						className={cn(orientation === "left" && "rotate-180", iconClassName)}
-					/>
-				),
-			}}
-			className="p-0"
-			classNames={{
-				root: "w-full",
-				months: "flex flex-col",
-				month: "p-0",
-				month_caption: "flex h-8 justify-center select-none",
-				caption: "relative flex h-20 items-center justify-center",
-				caption_label: "text-sm font-semibold text-gray-800",
-				nav: "contents",
-				button_previous:
-					"absolute top-8.5 left-7 -translate-y-1/2 cursor-pointer bg-transparent p-0 hover:bg-transparent",
-				button_next:
-					"absolute top-8.5 right-7 -translate-y-1/2 cursor-pointer bg-transparent p-0 hover:bg-transparent",
-				month_grid: "w-full border-collapse",
-				weekdays: "grid grid-cols-7",
-				weekday:
-					"flex h-8 items-center justify-center text-center text-sm font-semibold text-gray-600 select-none",
-				weeks: "flex flex-col",
-				week: "grid grid-cols-7",
-				day: "flex items-center justify-center",
-				day_button: cn(
-					"select-none flex h-8 w-full cursor-pointer items-center justify-center rounded-lg",
-					"text-sm font-medium text-gray-800",
-					"transition-colors",
-					"hover:bg-purple-100",
-					"focus:outline-none",
-				),
-				selected: "[&>button]:bg-purple-200 [&>button]:font-semibold [&>button]:text-purple-600",
-				today: "[&>button]:text-purple-600",
-				outside: "[&>button]:text-gray-400",
-				disabled: "[&>button]:cursor-not-allowed [&>button]:text-gray-100",
-				hidden: "invisible",
-			}}
+			selected={props.selectedDate}
+			onSelect={props.onSelectDate}
 		/>
 	);
 }

--- a/features/meetup/list/components/ListFilters.tsx
+++ b/features/meetup/list/components/ListFilters.tsx
@@ -93,13 +93,22 @@ export type RegionFilterParams = {
 } & RegionFilterValue;
 function DropdownFilters() {
 	const { get, set } = useQueryParams();
-	const date = get(QUERY_KEYS.DATE_START) ?? "";
+	const dateStart = get(QUERY_KEYS.DATE_START) ?? "";
+	const dateEnd = get(QUERY_KEYS.DATE_END) ?? "";
 	const region = transformRegionData(get(QUERY_KEYS.REGION));
 	const sortBy = getSortByItem(get(QUERY_KEYS.SORT_BY)) ?? SORT_BY_OPTIONS[0].value;
 	const sortOrder = getSortOrderItem(get(QUERY_KEYS.SORT_ORDER)) ?? SORT_ORDER_OPTIONS[0].value;
 
-	function handleChangeDate(v: string) {
-		set({ [QUERY_KEYS.DATE_START]: v, [QUERY_KEYS.DATE_END]: v });
+	const date = {
+		from: dateStart ? dateStart.split("T")[0] : "",
+		to: dateEnd ? dateEnd.split("T")[0] : "",
+	};
+
+	function handleChangeDate(v: { from: string; to: string }) {
+		set({
+			[QUERY_KEYS.DATE_START]: v.from,
+			[QUERY_KEYS.DATE_END]: v.to,
+		});
 	}
 	function handleChangeRegion(data: RegionFilterParams) {
 		set({ [QUERY_KEYS.REGION]: data.fullLabel });

--- a/features/reviews/components/ListControls/ListFilters.tsx
+++ b/features/reviews/components/ListControls/ListFilters.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import DateFilter from "@/components/ui/Filter/DateFilter";
 import RegionFilter from "@/components/ui/Filter/RegionFilter";
 import { FilterDropdown } from "@/components/ui/Filter/FilterDropdown";
@@ -9,7 +10,7 @@ import {
 	getRegionItem,
 	getSortByItem,
 	getSortOrderItem,
-	RegionFilterValue,
+	type RegionFilterValue,
 } from "@/features/reviews/utils";
 import {
 	QUERY_PARAM_KEYS,
@@ -19,42 +20,44 @@ import {
 
 export default function ListFilters() {
 	const { get, set } = useQueryParams();
+
 	const dateStart = get(QUERY_PARAM_KEYS.DATE_START);
+	const dateEnd = get(QUERY_PARAM_KEYS.DATE_END);
 	const region = getRegionItem(get(QUERY_PARAM_KEYS.REGION));
 	const sortBy = getSortByItem(get(QUERY_PARAM_KEYS.SORT_BY)) ?? REVIEWS_SORT_BY_OPTIONS[0].value;
 	const sortOrder =
 		getSortOrderItem(get(QUERY_PARAM_KEYS.SORT_ORDER)) ?? REVIEWS_SORT_ORDER_OPTIONS[0].value;
 
-	const dateValue = dateStart ? dateStart.split("T")[0] : "";
+	const [dateRange, setDateRange] = useState({
+		from: dateStart ? dateStart.split("T")[0] : "",
+		to: dateEnd ? dateEnd.split("T")[0] : "",
+	});
 
-	function handleChangeDate(v: string | null) {
-		if (!v) {
-			set({
-				[QUERY_PARAM_KEYS.DATE_START]: null,
-				[QUERY_PARAM_KEYS.DATE_END]: null,
-			});
-			return;
-		}
+	function handleChangeDate(value: { from: string; to: string }) {
+		setDateRange(value);
 
 		set({
-			[QUERY_PARAM_KEYS.DATE_START]: v,
-			[QUERY_PARAM_KEYS.DATE_END]: v,
+			[QUERY_PARAM_KEYS.DATE_START]: value.from || null,
+			[QUERY_PARAM_KEYS.DATE_END]: value.to || null,
 		});
 	}
+
 	function handleChangeLocation(data: RegionFilterValue) {
 		const param = buildRegionParam(data.region, data.district);
 		set({ [QUERY_PARAM_KEYS.REGION]: param });
 	}
+
 	function handleChangeSortOrder(v: string) {
 		set({ [QUERY_PARAM_KEYS.SORT_ORDER]: v });
 	}
+
 	function handleChangeSortBy(v: string) {
 		set({ [QUERY_PARAM_KEYS.SORT_BY]: v });
 	}
 
 	return (
 		<div role="group" aria-label="모임 필터 그룹" className="flex items-center justify-center">
-			<DateFilter value={dateValue} onChange={handleChangeDate} />
+			<DateFilter value={dateRange} onChange={handleChangeDate} />
 			<RegionFilter value={region} onChange={handleChangeLocation} />
 			<FilterDropdown
 				value={sortBy.label}

--- a/features/reviews/components/ListControls/ListFilters.tsx
+++ b/features/reviews/components/ListControls/ListFilters.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import DateFilter from "@/components/ui/Filter/DateFilter";
 import RegionFilter from "@/components/ui/Filter/RegionFilter";
 import { FilterDropdown } from "@/components/ui/Filter/FilterDropdown";
@@ -28,14 +27,12 @@ export default function ListFilters() {
 	const sortOrder =
 		getSortOrderItem(get(QUERY_PARAM_KEYS.SORT_ORDER)) ?? REVIEWS_SORT_ORDER_OPTIONS[0].value;
 
-	const [dateRange, setDateRange] = useState({
+	const dateRange = {
 		from: dateStart ? dateStart.split("T")[0] : "",
 		to: dateEnd ? dateEnd.split("T")[0] : "",
-	});
+	};
 
 	function handleChangeDate(value: { from: string; to: string }) {
-		setDateRange(value);
-
 		set({
 			[QUERY_PARAM_KEYS.DATE_START]: value.from || null,
 			[QUERY_PARAM_KEYS.DATE_END]: value.to || null,

--- a/hooks/useIsLg.ts
+++ b/hooks/useIsLg.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-// md 이상 여부를 반환하는 반응형 훅(캘린더 모달에서 사용)
+// lg 이상 여부를 반환하는 반응형 훅(캘린더 모달에서 사용)
 const MEDIA_QUERY = "(min-width:1280px)";
 
 const subscribe = (callback: () => void) => {

--- a/hooks/useIsLg.ts
+++ b/hooks/useIsLg.ts
@@ -1,7 +1,7 @@
 import { useSyncExternalStore } from "react";
 
 // md 이상 여부를 반환하는 반응형 훅(캘린더 모달에서 사용)
-const MEDIA_QUERY = "(min-width:744px)";
+const MEDIA_QUERY = "(min-width:1280px)";
 
 const subscribe = (callback: () => void) => {
 	const media = window.matchMedia(MEDIA_QUERY);
@@ -18,6 +18,6 @@ const getServerSnapshot = () => {
 	return false;
 };
 
-export function useIsMd() {
+export function useIsLg() {
 	return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

목록 api에서 필터링 파라미터 필드가 변경 됨에 따라
Calendar와 DateFilter를 수정하여 기존 단일 날짜 데이터 형식에서 범위 날짜 형식으로 수정했습니다.

## 📝 변경 사항 요약 (Summary) & 💁 변경 사항 이유 (Why)

- `DateFilter`
    - 데이터 형식을 from, to의 문자열 객체 형태로 받도록 수정
- `useIsMd`
    - 모바일 버전에서 DateFilter의 패널이 왼쪽으로 출력되며 잘리는 현상이 있어 모바일에서는 오른쪽으로 출력되도록 ui 수정
- `Calendar` mode="range" 추가
    - 단일 날짜 모드 또는 범위 날짜 모드 둘다 필요하여 선택할 수 있도록 mode prop 추가
- `ListFilters`
    - 바뀐 DateFilter에 맞춰 from, to 필드를 사용하여 쿼리스트링 변경될 수 있도록 수정.

## 👩🏻‍💻 사용법
부모에서 값을 주고 받을 때 아래와 같이 사용하시면 됩니다.

```javascript
const [dateRange, setDateRange] = useState({
	from: "",
	to: "",
});

<DateFilter value={dateRange} onChange={setDateRange} />;
```

## ✅ 테스트 계획 (Test Plan)

- 개발환경 및 스토리북에서 수동 테스트 진행했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #234 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
