### PR TITLE
refactor: 토큰 재발급 로직 개선

### DIFF
--- a/libs/refreshToken.ts
+++ b/libs/refreshToken.ts
@@ -27,7 +27,7 @@ export async function refreshToken(): Promise<string | null> {
 		return null;
 	}
 
-	let data: { accessToken: string; refreshToken: string };
+	let data: { accessToken: string; refreshToken: string | null };
 	try {
 		data = await response.json();
 	} catch {
@@ -36,16 +36,20 @@ export async function refreshToken(): Promise<string | null> {
 
 	const { accessToken: newAccessToken, refreshToken: newRefreshToken } = data;
 
-	if (!newAccessToken || !newRefreshToken) return null;
+	if (!newAccessToken) return null;
 
 	cookieStore.set("accessToken", newAccessToken, {
 		...COOKIE_OPTIONS,
 		maxAge: ACCESS_TOKEN_MAX_AGE,
 	});
-	cookieStore.set("refreshToken", newRefreshToken, {
-		...COOKIE_OPTIONS,
-		maxAge: REFRESH_TOKEN_MAX_AGE,
-	});
+
+	// refreshToken이 null로 오면 → 기존 토큰 유지 else{}
+	if (newRefreshToken) {
+		cookieStore.set("refreshToken", newRefreshToken, {
+			...COOKIE_OPTIONS,
+			maxAge: REFRESH_TOKEN_MAX_AGE,
+		});
+	}
 
 	return newAccessToken;
 }

--- a/libs/serverFetch.ts
+++ b/libs/serverFetch.ts
@@ -3,9 +3,6 @@ import { refreshToken } from "./refreshToken";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
-// 현재 요청 안에서 공유되는 refresh Promise (사용자들끼리 섞이지 않도록)
-const refreshMap = new Map<string, Promise<string | null>>();
-
 async function fetchWithToken(endpoint: string, options: RequestInit, accessToken?: string) {
 	const { headers, ...rest } = options;
 
@@ -22,36 +19,16 @@ async function fetchWithToken(endpoint: string, options: RequestInit, accessToke
 export async function serverFetch(endpoint: string, options: RequestInit = {}) {
 	const cookieStore = await cookies();
 	const accessToken = cookieStore.get("accessToken")?.value;
-	const refreshTokenValue = cookieStore.get("refreshToken")?.value;
 
 	const response = await fetchWithToken(endpoint, options, accessToken);
 
-	// 정상 응답이면 그대로 반환
 	if (response.status !== 401) {
 		return response;
 	}
 
-	// refreshToken이 없으면 그대로 401 반환
-	if (!refreshTokenValue) {
-		return response;
-	}
+	const newAccessToken = await refreshToken();
 
-	// refresh 진행 중이면 그 Promise 재사용
-	if (!refreshMap.has(refreshTokenValue)) {
-		const refreshPromise = refreshToken().finally(() => {
-			setTimeout(() => refreshMap.delete(refreshTokenValue), 10_000);
-		});
+	if (!newAccessToken) return response;
 
-		refreshMap.set(refreshTokenValue, refreshPromise);
-	}
-
-	const newAccessToken = await refreshMap.get(refreshTokenValue);
-
-	// refresh 실패 시 원래 401 응답 반환
-	if (!newAccessToken) {
-		return response;
-	}
-
-	// 새 토큰으로 원래 요청 재시도
 	return fetchWithToken(endpoint, options, newAccessToken);
 }


### PR DESCRIPTION
 ## 🛠️ 설명 (Description)
  Vercel 서버리스 환경에서는 인스턴스가 요청마다 새로 생성되어 `refreshMap`이 요청 간 공유되지
  않습니다.
  백엔드에서 grace period 정책으로 중복 refresh 요청을 처리하는 방식으로 변경됨에 따라 클라이언트
  토큰 재발급 로직을 개선합니다.

  ## 📝 변경 사항 요약 (Summary)
  - `refreshMap` 제거 — 서버리스 환경에서 인스턴스 간 공유가 불가하여 불필요
  - refresh 응답의 `refreshToken`이 `null`인 경우 기존 쿠키 유지 처리 추가

  ## 💁 변경 사항 이유 (Why)
  - 서버리스 환경에서 `refreshMap`은 같은 요청 내에서도 인스턴스가 분리될 수 있어 레이스 컨디션
  방지 효과가 없음
  - 백엔드 grace period 정책: 동일 refresh token으로 10초 내 중복 요청 시 `accessToken`은 새로
  발급하되 `refreshToken`은 `null` 반환 → 클라이언트는 기존 토큰 유지

  ## ✅ 테스트 계획 (Test Plan)
  - 액세스 토큰 만료 상태에서 API 요청 시 자동 재발급 후 정상 응답 확인

  ## 🔗 관련 이슈 (Related Issues)
  - Closed #239

  ## ☑️ 체크리스트 (Checklist)
  - [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
  - [ ] 테스트 코드가 작성되었고, 통과했습니다.
  - [ ] 변경 사항에 대한 문서화가 완료되었습니다.
  - [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
  - [x] CI/CD 파이프라인이 성공했습니다.

  ## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
  백엔드 grace period 정책에 따라 `refreshToken: null` 응답은 에러가 아닌 정상 케이스입니다. 기존
  쿠키를 유지해야 최신 refresh token이 덮어써지지 않습니다.

  ## ➕ 추가 정보 (Additional Information)
  없음