### PR TITLE
fix(meetup): 모임 찾기 필터링 데이터 버그 수정

### DIFF
--- a/app/(main)/meetup/list/page.tsx
+++ b/app/(main)/meetup/list/page.tsx
@@ -12,8 +12,8 @@ export default function MeetupListPage() {
 			<div className="mt-6 mb-10 flex flex-1 flex-col gap-y-5 px-4 md:mt-10 md:mb-12 md:gap-y-4 md:px-0 lg:mt-12 lg:mb-26 lg:gap-y-6">
 				<Suspense fallback={null}>
 					<ListFilters />
+					<MeetupCardList />
 				</Suspense>
-				<MeetupCardList />
 			</div>
 			<Suspense fallback={null}>
 				<CreateOpenButton className="fixed right-4 bottom-6 md:right-5.5 md:bottom-5.5 lg:right-[85px] lg:bottom-14" />

--- a/features/meetup/list/components/ListFilters.tsx
+++ b/features/meetup/list/components/ListFilters.tsx
@@ -112,7 +112,7 @@ function DropdownFilters() {
 	}
 
 	return (
-		<div className="flex items-center lg:ml-auto">
+		<div className="flex items-center gap-x-1.5 lg:ml-auto">
 			<DateFilter value={date} onChange={handleChangeDate} />
 			<RegionFilter value={region} onChange={handleChangeRegion} />
 			<FilterDropdown value={sortBy.label} items={SORT_BY_OPTIONS} onChange={handleChangeSortBy} />

--- a/features/meetup/list/components/MeetupCardItems.tsx
+++ b/features/meetup/list/components/MeetupCardItems.tsx
@@ -3,21 +3,24 @@
 import { useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { ErrorBoundary } from "react-error-boundary";
+import type { InfiniteData, UseInfiniteQueryResult } from "@tanstack/react-query";
+import type { MeetupItem, MeetupItemSelected, MeetupListResponse } from "../../types";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
-import { MeetupItem, MeetupItemSelected } from "../../types";
 import useToggle from "@/hooks/useToggle";
-import { useGetMeetups } from "@/features/meetup/queries";
 import MeetupCard from "@/features/meetup/list/components/MeetupCard";
-import GroupCard from "@/components/ui/GroupCard";
 import LoaderDots from "@/components/ui/LoaderDots";
 import Empty from "./Emtpy";
 import JoinModal from "./JoinModal";
 
-export default function MeetupCardItems({ size }: { size: number }) {
+interface MeetupCardItemsProps {
+	query: UseInfiniteQueryResult<InfiniteData<MeetupListResponse>>;
+}
+
+export default function MeetupCardItems({ query }: MeetupCardItemsProps) {
+	const { data, isFetchingNextPage, hasNextPage, fetchNextPage } = query;
 	const [selectedData, setSelectedData] = useState<MeetupItemSelected>(null);
 	const { isOpen, open, close } = useToggle();
-	const { data, isLoading, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
-		useGetMeetups(size);
+
 	const loadMoreRef = useRef<HTMLDivElement>(null);
 	useIntersectionObserver({
 		targetRef: loadMoreRef,
@@ -25,7 +28,6 @@ export default function MeetupCardItems({ size }: { size: number }) {
 		isEnabled: hasNextPage && !isFetchingNextPage,
 	});
 
-	if (isPending || isLoading) return <MeetupCardSkeletonItems size={size} />;
 	return (
 		<ErrorBoundary fallbackRender={() => <LastItem>에러가 발생했습니다.</LastItem>}>
 			<MeetupCardLoadedItems
@@ -98,14 +100,6 @@ const cardVariants = {
 		},
 	},
 };
-
-export function MeetupCardSkeletonItems({ size }: { size: number }) {
-	return Array.from({ length: size }).map((_, i) => (
-		<li key={i} className="w-full">
-			<GroupCard.Skeleton />
-		</li>
-	));
-}
 
 interface LastItemProps {
 	ref?: React.RefObject<HTMLDivElement | null>;

--- a/features/meetup/list/components/MeetupCardItems.tsx
+++ b/features/meetup/list/components/MeetupCardItems.tsx
@@ -3,47 +3,21 @@
 import { useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { ErrorBoundary } from "react-error-boundary";
-import { useQueryParams } from "@/hooks/useQueryParams";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
-import useToggle from "@/hooks/useToggle";
-import { QUERY_KEYS } from "../constants";
 import { MeetupItem, MeetupItemSelected } from "../../types";
-import {
-	transformQueryValue,
-	transformTypeValue,
-	transformSortByQuery,
-	transformSortOrderQuery,
-	transformDateStartQuery,
-	transformDateEndQuery,
-} from "../utils";
+import useToggle from "@/hooks/useToggle";
 import { useGetMeetups } from "@/features/meetup/queries";
 import MeetupCard from "@/features/meetup/list/components/MeetupCard";
 import GroupCard from "@/components/ui/GroupCard";
 import LoaderDots from "@/components/ui/LoaderDots";
 import Empty from "./Emtpy";
 import JoinModal from "./JoinModal";
-import { useUserStore } from "@/store/user.store";
 
 export default function MeetupCardItems({ size }: { size: number }) {
-	const { isPending } = useUserStore();
-	// 인증 여부가 결정되지 않은 경우 스켈레톤 표시(데이터 중복 호출 방지)
-	if (isPending) return <MeetupCardSkeletonItems size={size} />;
-	return <MeetupCardListContent size={size} />;
-}
-
-function MeetupCardListContent({ size }: { size: number }) {
 	const [selectedData, setSelectedData] = useState<MeetupItemSelected>(null);
 	const { isOpen, open, close } = useToggle();
-	const { get } = useQueryParams();
-	const { data, isFetchingNextPage, hasNextPage, fetchNextPage } = useGetMeetups({
-		type: transformTypeValue(get(QUERY_KEYS.TYPE)),
-		region: transformQueryValue(get(QUERY_KEYS.REGION)),
-		dateStart: transformDateStartQuery(get(QUERY_KEYS.DATE_START)),
-		dateEnd: transformDateEndQuery(get(QUERY_KEYS.DATE_END)),
-		sortBy: transformSortByQuery(get(QUERY_KEYS.SORT_BY)),
-		sortOrder: transformSortOrderQuery(get(QUERY_KEYS.SORT_ORDER)),
-		size,
-	});
+	const { data, isLoading, isPending, isFetchingNextPage, hasNextPage, fetchNextPage } =
+		useGetMeetups(size);
 	const loadMoreRef = useRef<HTMLDivElement>(null);
 	useIntersectionObserver({
 		targetRef: loadMoreRef,
@@ -51,6 +25,7 @@ function MeetupCardListContent({ size }: { size: number }) {
 		isEnabled: hasNextPage && !isFetchingNextPage,
 	});
 
+	if (isPending || isLoading) return <MeetupCardSkeletonItems size={size} />;
 	return (
 		<ErrorBoundary fallbackRender={() => <LastItem>에러가 발생했습니다.</LastItem>}>
 			<MeetupCardLoadedItems

--- a/features/meetup/list/components/MeetupCardList.tsx
+++ b/features/meetup/list/components/MeetupCardList.tsx
@@ -1,13 +1,35 @@
 "use client";
 
+import GroupCard from "@/components/ui/GroupCard";
+import { useGetMeetups } from "../../queries";
 import MeetupCardItems from "./MeetupCardItems";
+import { cn } from "@/utils/cn";
 
 const size = 10;
 
 export default function MeetupCardList() {
+	const query = useGetMeetups(size);
+	const isRefetching = query.isFetching && !query.isFetchingNextPage && !query.isPending;
+
 	return (
-		<ul className="grid w-full content-start justify-items-stretch gap-4 md:gap-6 lg:grid-cols-2">
-			<MeetupCardItems size={size} />
+		<ul
+			className={cn(
+				"grid w-full content-start justify-items-stretch gap-4 transition-opacity duration-200 ease-in-out md:gap-6 lg:grid-cols-2",
+				isRefetching && "pointer-events-none opacity-50",
+			)}>
+			{query.isPending ? (
+				<MeetupCardSkeletonItems size={size} />
+			) : (
+				<MeetupCardItems query={query} />
+			)}
 		</ul>
 	);
+}
+
+function MeetupCardSkeletonItems({ size }: { size: number }) {
+	return Array.from({ length: size }).map((_, i) => (
+		<li key={i} className="w-full">
+			<GroupCard.Skeleton />
+		</li>
+	));
 }

--- a/features/meetup/list/components/MeetupCardList.tsx
+++ b/features/meetup/list/components/MeetupCardList.tsx
@@ -1,21 +1,13 @@
 "use client";
 
-import { MeetupCardSkeletonItems } from "@/features/meetup/list/components/MeetupCardItems";
-import dynamic from "next/dynamic";
-import { Suspense } from "react";
+import MeetupCardItems from "./MeetupCardItems";
 
 const size = 10;
-const MeetupCardItems = dynamic(() => import("@/features/meetup/list/components/MeetupCardItems"), {
-	ssr: false,
-	loading: () => <MeetupCardSkeletonItems size={size} />,
-});
 
-export default function MeetupCardListWrapper() {
+export default function MeetupCardList() {
 	return (
 		<ul className="grid w-full content-start justify-items-stretch gap-4 md:gap-6 lg:grid-cols-2">
-			<Suspense fallback={<MeetupCardSkeletonItems size={size} />}>
-				<MeetupCardItems size={size} />
-			</Suspense>
+			<MeetupCardItems size={size} />
 		</ul>
 	);
 }

--- a/features/meetup/queries.ts
+++ b/features/meetup/queries.ts
@@ -3,8 +3,9 @@ import {
 	useInfiniteQuery,
 	useMutation,
 	UseMutationOptions,
+	useQueryClient,
 } from "@tanstack/react-query";
-import { MeetupCreateRequest, MeetupItemResponse, MeetupListRequest } from "./types";
+import type { MeetupCreateRequest, MeetupItemResponse, MeetupListRequest } from "./types";
 import { getMeetups, postMeetup } from "./apis";
 import {
 	deleteMeetingsFavorite,
@@ -25,6 +26,7 @@ import {
 } from "./list/utils";
 import { QUERY_KEYS } from "./list/constants";
 import { useQueryParams } from "@/hooks/useQueryParams";
+import { useEffect } from "react";
 
 type MutationCallbacks<TData, TVariables = void> = Omit<
 	UseMutationOptions<TData, Error, TVariables>,
@@ -33,8 +35,7 @@ type MutationCallbacks<TData, TVariables = void> = Omit<
 
 export const meetupQueryKeys = {
 	list: ["meetup", "list"] as const,
-	listWithParams: (params: MeetupListRequest, userId: number | null) =>
-		[...meetupQueryKeys.list, params, userId] as const,
+	listWithParams: (params: MeetupListRequest) => [...meetupQueryKeys.list, params] as const,
 };
 
 export const meetupMutationKeys = {
@@ -48,7 +49,8 @@ export const meetupMutationKeys = {
 
 /** 모임 목록 조회 */
 export function useGetMeetups(size: number) {
-	const { isPending, user } = useUserStore();
+	const queryClient = useQueryClient();
+	const { user } = useUserStore();
 	const { get } = useQueryParams();
 	const params = {
 		type: transformTypeValue(get(QUERY_KEYS.TYPE)),
@@ -60,14 +62,19 @@ export function useGetMeetups(size: number) {
 		size,
 	};
 
+	useEffect(() => {
+		queryClient.invalidateQueries({
+			queryKey: meetupQueryKeys.listWithParams(params),
+		});
+	}, [user?.id]);
+
 	// [FIX] useSuspenseInfiniteQuery + Suspense 사용 시 AnimatePresence 에서 렌더링 이슈 발생
 	return useInfiniteQuery({
-		queryKey: meetupQueryKeys.listWithParams(params, user?.id ?? null),
+		queryKey: meetupQueryKeys.listWithParams(params),
 		queryFn: ({ pageParam }) => getMeetups({ ...params, cursor: pageParam }),
 		getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
 		initialPageParam: undefined as string | undefined,
 		placeholderData: keepPreviousData,
-		enabled: !isPending,
 		refetchOnWindowFocus: false,
 		staleTime: 0,
 		gcTime: 5 * 60 * 1000, // 5분

--- a/features/meetup/queries.ts
+++ b/features/meetup/queries.ts
@@ -1,6 +1,11 @@
-import { useMutation, UseMutationOptions, useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { getMeetups, postMeetup } from "./apis";
+import {
+	keepPreviousData,
+	useInfiniteQuery,
+	useMutation,
+	UseMutationOptions,
+} from "@tanstack/react-query";
 import { MeetupCreateRequest, MeetupItemResponse, MeetupListRequest } from "./types";
+import { getMeetups, postMeetup } from "./apis";
 import {
 	deleteMeetingsFavorite,
 	deleteMeetingsJoin,
@@ -10,6 +15,16 @@ import {
 } from "@/apis/meetings";
 import { uploadImage } from "@/apis/images";
 import { useUserStore } from "@/store/user.store";
+import {
+	transformDateEndQuery,
+	transformDateStartQuery,
+	transformQueryValue,
+	transformSortByQuery,
+	transformSortOrderQuery,
+	transformTypeValue,
+} from "./list/utils";
+import { QUERY_KEYS } from "./list/constants";
+import { useQueryParams } from "@/hooks/useQueryParams";
 
 type MutationCallbacks<TData, TVariables = void> = Omit<
 	UseMutationOptions<TData, Error, TVariables>,
@@ -32,14 +47,27 @@ export const meetupMutationKeys = {
 };
 
 /** 모임 목록 조회 */
-export function useGetMeetups(params: MeetupListRequest) {
-	const userId = useUserStore((state) => state.user?.id ?? null);
-	// 유저(미인증 포함)가 변경되면 refetch
-	return useSuspenseInfiniteQuery({
-		queryKey: meetupQueryKeys.listWithParams(params, userId),
+export function useGetMeetups(size: number) {
+	const { isPending, user } = useUserStore();
+	const { get } = useQueryParams();
+	const params = {
+		type: transformTypeValue(get(QUERY_KEYS.TYPE)),
+		region: transformQueryValue(get(QUERY_KEYS.REGION)),
+		dateStart: transformDateStartQuery(get(QUERY_KEYS.DATE_START)),
+		dateEnd: transformDateEndQuery(get(QUERY_KEYS.DATE_END)),
+		sortBy: transformSortByQuery(get(QUERY_KEYS.SORT_BY)),
+		sortOrder: transformSortOrderQuery(get(QUERY_KEYS.SORT_ORDER)),
+		size,
+	};
+
+	// [FIX] useSuspenseInfiniteQuery + Suspense 사용 시 AnimatePresence 에서 렌더링 이슈 발생
+	return useInfiniteQuery({
+		queryKey: meetupQueryKeys.listWithParams(params, user?.id ?? null),
 		queryFn: ({ pageParam }) => getMeetups({ ...params, cursor: pageParam }),
 		getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
 		initialPageParam: undefined as string | undefined,
+		placeholderData: keepPreviousData,
+		enabled: !isPending,
 		refetchOnWindowFocus: false,
 		staleTime: 0,
 		gcTime: 5 * 60 * 1000, // 5분


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 찾기 필터링에서 이전 필터값 데이터가 표시되는 버그를 수정하였습니다.

## 📝 변경 사항 요약 (Summary)

- `useSuspenseInfiniteQuery`와 `Suspense`를 제거하고 `useInfiniteQuery`를 적용하였습니다.
- `placeholderData` 옵션을 추가하였습니다.
- 추가: `enabled` 옵션을 삭제하고 queryKey 에서 `user.id` 제거 및 useEffect 를 추가하였습니다.
- 추가: 우측 필터 목록 간격을 적용하였습니다.

## 💁 변경 사항 이유 (Why)

`AnimatePresence`와 `Suspense` 간 충돌로 인해 빌드 환경에서 문제가 발생했습니다.
개발 환경에서도 StrictMode 옵션을 제거했을 때 동일 증상이 발생하는 것을 확인하였습니다. 

## ✅ 테스트 계획 (Test Plan)

- 수동 테스트를 진행하였습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #232 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.
