### PR TITLE
[BUG] Filter-hydration mismatch가 발생하는 버그를 수정

### DIFF
--- a/components/ui/Filter/DateFilter/index.tsx
+++ b/components/ui/Filter/DateFilter/index.tsx
@@ -29,11 +29,9 @@ export default function DateFilter({ value = "", onChange }: DateFilterProps) {
 		<Popover className="relative">
 			{({ close }) => (
 				<>
-					<PopoverButton as="div">
-						<FilterTrigger isActive={!!parsed}>
-							<span>{parsed ? formatDisplayDate(parsed) : "날짜 전체"}</span>
-							<IcChevronDown className="h-4 w-4" />
-						</FilterTrigger>
+					<PopoverButton as={FilterTrigger} isActive={!!parsed}>
+						<span>{parsed ? formatDisplayDate(parsed) : "날짜 전체"}</span>
+						<IcChevronDown className="h-4 w-4" />
 					</PopoverButton>
 
 					<PopoverPanel

--- a/components/ui/Filter/DateFilter/index.tsx
+++ b/components/ui/Filter/DateFilter/index.tsx
@@ -80,11 +80,9 @@ export default function DateFilter({ value = { from: "", to: "" }, onChange }: D
 		<Popover className="relative">
 			{({ close }) => (
 				<>
-					<PopoverButton as="div">
-						<FilterTrigger isActive={!!parsedRange?.from}>
-							<span>{formatDisplayRange(parsedRange)}</span>
-							<IcChevronDown className="h-4 w-4" />
-						</FilterTrigger>
+					<PopoverButton as={FilterTrigger} isActive={!!parsedRange}>
+						<span>{formatDisplayRange(parsedRange)}</span>
+						<IcChevronDown className="h-4 w-4" />
 					</PopoverButton>
 
 					<PopoverPanel

--- a/components/ui/Filter/FilterDropdown/index.tsx
+++ b/components/ui/Filter/FilterDropdown/index.tsx
@@ -21,11 +21,9 @@ export function FilterDropdown({ value, items, onChange }: FilterDropdownProps) 
 
 	return (
 		<Menu as="div" className="relative inline-block">
-			<MenuButton as="div">
-				<FilterTrigger isActive={!!value}>
-					<IcFilter className="h-4 w-4" />
-					<span>{selectedItem?.label ?? value}</span>
-				</FilterTrigger>
+			<MenuButton as={FilterTrigger} isActive={!!value}>
+				<IcFilter className="h-4 w-4" />
+				<span>{selectedItem?.label ?? value}</span>
 			</MenuButton>
 
 			<MenuItems

--- a/components/ui/Filter/FilterTrigger.tsx
+++ b/components/ui/Filter/FilterTrigger.tsx
@@ -31,6 +31,7 @@ const FilterTrigger = forwardRef<HTMLButtonElement, FilterTriggerProps>(function
 				// 리셋
 				"border-none bg-transparent shadow-none",
 
+				"outline-none",
 				className,
 			)}
 			{...props}>

--- a/components/ui/Filter/FilterTrigger.tsx
+++ b/components/ui/Filter/FilterTrigger.tsx
@@ -1,25 +1,21 @@
-import Button from "@/components/ui/Buttons/Button";
+// components/ui/Filter/FilterTrigger.tsx
+import { forwardRef } from "react";
 import { cn } from "@/utils/cn";
 
-interface FilterTriggerProps {
-	children: React.ReactNode;
+interface FilterTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 	isActive?: boolean;
-	onClick?: () => void;
-	className?: string;
 }
 
-export default function FilterTrigger({
-	children,
-	isActive = false,
-	onClick,
-	className,
-}: FilterTriggerProps) {
+const FilterTrigger = forwardRef<HTMLButtonElement, FilterTriggerProps>(function FilterTrigger(
+	{ children, isActive = false, className, ...props },
+	ref,
+) {
 	return (
-		<Button
-			onClick={onClick}
-			colors="grayBorder"
+		<button
+			ref={ref}
+			type="button"
 			className={cn(
-				//  Button 덮어쓰기
+				// 사이즈
 				"h-6 w-auto px-0 md:h-8",
 				"rounded-lg",
 
@@ -29,15 +25,18 @@ export default function FilterTrigger({
 				// 상태
 				isActive ? "border-gray-300 text-gray-800" : "border-gray-200 text-gray-600",
 
-				// layout
+				// 레이아웃
 				"flex items-center gap-1 whitespace-nowrap",
 
-				"border-none shadow-none",
-				"bg-transparent",
+				// 리셋
+				"border-none bg-transparent shadow-none",
 
 				className,
-			)}>
+			)}
+			{...props}>
 			{children}
-		</Button>
+		</button>
 	);
-}
+});
+
+export default FilterTrigger;

--- a/components/ui/Filter/RegionFilter/RegionModal.tsx
+++ b/components/ui/Filter/RegionFilter/RegionModal.tsx
@@ -79,7 +79,7 @@ export default function RegionModal({
 					<h2 className="text-lg leading-7 font-semibold md:text-2xl md:leading-8">지역 선택</h2>
 
 					{/* 모달 닫기 버튼 */}
-					<button onClick={onClose} className="cursor-pointer">
+					<button type="button" onClick={onClose} className="cursor-pointer">
 						<IcDelete />
 					</button>
 				</div>


### PR DESCRIPTION
## 🛠️ 설명 (Description)

FilterDropdown에서 MenuButton을 `as="div"`로 우회하는 과정에서
Headless UI가 서버/클라이언트에 서로 다른 id를 생성해
hydration mismatch가 발생하는 버그를 수정했습니다

동일한 문제인 DateFilter의 PopoverButton에서도 동일한 방법으로 수정했습니다

## 📝 변경 사항 요약 (Summary)

- `FilterTrigger`에 `forwardRef` 적용 및 `button` 태그로 직접 구현
- `FilterDropdown`의 `MenuButton as="div"` → `MenuButton as={FilterTrigger}`로 변경
- `PopoverButton as="div"` → `PopoverButton as={FilterTrigger}`로 변경

## 💁 변경 사항 이유 (Why)

-  `MenuButton as="div"`는 Headless UI가 내부 id를 직접 생성하게 만들어
  서버/클라이언트 간 id 불일치로 hydration mismatch 발생
- `forwardRef`로 ref를 button DOM에 직접 연결하면
  Headless UI가 id를 자체 생성할 필요가 없어져 문제 해결
- `MenuButton as={FilterTrigger}` 적용으로 button 중첩 문제도 함께 해결

## ✅ 테스트 계획 (Test Plan)

- [x] 필터 드롭다운 클릭 시 정상 동작 확인
- [x] 모임찾기 페이지 필터 정상 동작 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #243 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

 `Button` 컴포넌트로 구현시 구조가 더 복잡해지는것 같아서 `button` 태그로 구현 했습니다
 공용 컴포넌트 `Button`에 `forwardRef`를 추가하는 방식으로 가야할지 고민이 됩니다
 현재는 `button` 태그로 직접 구현했으며 기존 스타일은 그대로 유지했습니다

## ➕ 추가 정보 (Additional Information)
