### PR TITLE
refactor: 유저 상태 이중 관리 구조 개선

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,9 @@ import { MemberProvider } from "@/providers/member-provider";
 import CategoryInitializer from "@/providers/category-provider";
 import { initMeetingTypes } from "@/apis/meetingTypes";
 import { Metadata } from "next";
+import { QueryClient, HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { getMeServer } from "@/features/auth/queries.server";
+import { cookies } from "next/headers";
 
 const pretendard = localFont({
 	src: "../public/assets/fonts/PretendardVariable.woff2",
@@ -90,18 +93,32 @@ export default async function RootLayout({
 	children: React.ReactNode;
 }>) {
 	const categories = await initMeetingTypes();
+	const queryClient = new QueryClient();
+	const cookieStore = await cookies();
+	const accessToken = cookieStore.get("accessToken")?.value;
+
+	if (accessToken) {
+		await queryClient
+			.prefetchQuery({
+				queryKey: ["me"],
+				queryFn: getMeServer,
+			})
+			.catch(() => {});
+	}
 
 	return (
 		<html lang="ko">
 			<body className={pretendard.className}>
 				<CategoryInitializer data={categories} />
 				<QueryProvider>
-					<ToastProvider>
-						<MemberProvider>
-							<Header />
-							{children}
-						</MemberProvider>
-					</ToastProvider>
+					<HydrationBoundary state={dehydrate(queryClient)}>
+						<ToastProvider>
+							<MemberProvider>
+								<Header />
+								{children}
+							</MemberProvider>
+						</ToastProvider>
+					</HydrationBoundary>
 				</QueryProvider>
 			</body>
 		</html>

--- a/features/auth/mutations.ts
+++ b/features/auth/mutations.ts
@@ -1,18 +1,17 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useUserStore } from "@/store/user.store";
 import { postLogin, postSignUp, postLogout } from "@/features/auth/apis";
 import { useToast } from "@/providers/toast-provider";
 import { useRouter } from "next/navigation";
 
 export function useLogin(onSuccess: () => void) {
-	const { setUser } = useUserStore();
+	const queryClient = useQueryClient();
 	const { handleShowToast } = useToast();
 	const router = useRouter();
 
 	return useMutation({
 		mutationFn: postLogin,
 		onSuccess: (data) => {
-			setUser(data.user);
+			queryClient.setQueryData(["me"], data.user);
 			handleShowToast({ message: "로그인이 완료됐습니다.", status: "success" });
 			onSuccess();
 			router.refresh();
@@ -24,7 +23,7 @@ export function useLogin(onSuccess: () => void) {
 }
 
 export function useSignUp(onSuccess: () => void, onAutoLoginFail?: () => void) {
-	const { setUser } = useUserStore();
+	const queryClient = useQueryClient();
 	const { handleShowToast } = useToast();
 
 	return useMutation({
@@ -35,7 +34,7 @@ export function useSignUp(onSuccess: () => void, onAutoLoginFail?: () => void) {
 					email: variables.email,
 					password: variables.password,
 				});
-				setUser(loginResult.user);
+				queryClient.setQueryData(["me"], loginResult.user);
 
 				handleShowToast({ message: "회원가입이 완료됐습니다.", status: "success" });
 				onSuccess();
@@ -54,7 +53,6 @@ export function useSignUp(onSuccess: () => void, onAutoLoginFail?: () => void) {
 }
 
 export function useLogout() {
-	const { clearUser } = useUserStore();
 	const { handleShowToast } = useToast();
 	const queryClient = useQueryClient();
 	const router = useRouter();
@@ -62,7 +60,6 @@ export function useLogout() {
 	return useMutation({
 		mutationFn: postLogout,
 		onSuccess: () => {
-			clearUser();
 			queryClient.removeQueries({ queryKey: ["me"] });
 			handleShowToast({ message: "로그아웃 됐습니다.", status: "success" });
 			router.refresh();

--- a/features/auth/queries.server.ts
+++ b/features/auth/queries.server.ts
@@ -1,0 +1,8 @@
+import { serverFetch } from "@/libs/serverFetch";
+import { User } from "@/features/auth/types";
+
+export async function getMeServer(): Promise<User> {
+	const response = await serverFetch("/users/me");
+	if (!response.ok) throw new Error("유저 정보 조회 실패");
+	return response.json();
+}

--- a/features/auth/queries.ts
+++ b/features/auth/queries.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { clientFetch } from "@/libs/clientFetch";
 import { User } from "@/features/auth/types";
-
 async function getMe(): Promise<User> {
 	const response = await clientFetch("/users/me");
 

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,0 +1,11 @@
+import { useGetMe } from "@/features/auth/queries";
+
+export function useUser() {
+	const { data: user, isPending, isError } = useGetMe();
+	return {
+		user: user ?? null,
+		isLoggedIn: !!user,
+		isPending,
+		isError,
+	};
+}


### PR DESCRIPTION
resolves: #253

## 🛠️ 설명 (Description)

  TanStack Query와 Zustand에 이중으로 관리되던 유저 데이터를 TanStack Query 단일 캐시로 통합합니다.
  useUser() 훅을 도입하고, SSR 환경에서 서버사이드 prefetch를 적용하여 초기 렌더링 시 유저 정보를
  미리 불러옵니다.

## 📄 설계 문서 (Design Document)


## 📝 변경 사항 요약 (Summary)

 - hooks/useUser.ts 신규 생성: TanStack Query 기반 유저 정보 접근 훅
  - features/auth/queries.server.ts 신규 생성: SSR 전용 유저 정보 조회 함수 분리 (next/headers
  클라이언트 번들 분리 목적)
  - features/auth/mutations.ts 수정: 로그인/회원가입/로그아웃에서 Zustand setUser/clearUser 제거 →
  queryClient.setQueryData / queryClient.removeQueries로 대체
  - app/layout.tsx 수정: accessToken이 있을 때 서버에서 prefetchQuery로 유저 정보 미리 패칭 후
  HydrationBoundary로 클라이언트에 전달

## 💁 변경 사항 이유 (Why)

  - Zustand와 TanStack Query에 유저 데이터가 이중으로 저장되어 상태 동기화 실패 시 UI 불일치가
  발생할 수 있었음
  - TanStack Query 캐시를 단일 진실 공급원(Single Source of Truth)으로 삼아 일관성 확보
  - SSR prefetch를 통해 로그인 유저가 페이지 진입 시 유저 정보를 즉시 사용할 수 있도록 개선

## ✅ 테스트 계획 (Test Plan)

  - 로그인 → 유저 정보 정상 표시 확인
  - 로그아웃 → 유저 정보 초기화 및 UI 반영 확인
  - 비로그인 상태에서 페이지 진입 시 오류 없음 확인 (prefetch 조건부 처리)
  - 로그인 상태에서 새로고침 시 SSR Hydration으로 유저 정보 즉시 표시 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #253
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

  - useUserStore → useUser()로의 전체 마이그레이션은 이 PR 머지 후 각 팀원이 담당 파일에서 직접 진행합니다.
  - MemberProvider, useUserStore 스토어 파일 삭제는 전체 마이그레이션 완료 후 별도 브랜치/PR로 진행 예정입니다.
  - queries.server.ts를 별도 파일로 분리한 이유: serverFetch가 next/headers를 사용하므로 클라이언트 번들에 포함되면 빌드 에러 발생

## ➕ 추가 정보 (Additional Information)
https://www.notion.so/31446d4d7ef78029933cf1b3986c48d4?p=33d46d4d7ef78098b1a2e5d91da8a289&pm=s