### PR TITLE
[feat] connect 페이지 에러 바운더리 적용

### DIFF
--- a/app/(main)/connect/[id]/page.tsx
+++ b/app/(main)/connect/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { getPostDetailServer } from "@/features/connect/apis/getPostDetailServer";
 import { QueryClient, dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import PostDetailContainer from "@/features/connect/containers/PostDetailContainer";
+import { ErrorBoundary } from "react-error-boundary";
+import ConnectErrorFallback from "@/features/connect/components/ErrorBoundary";
 
 export default async function DetailPage({ params }: { params: Promise<{ id: string }> }) {
 	const { id } = await params;
@@ -20,7 +22,9 @@ export default async function DetailPage({ params }: { params: Promise<{ id: str
 
 	return (
 		<HydrationBoundary state={dehydrate(queryClient)}>
-			<PostDetailContainer id={numId} />
+			<ErrorBoundary FallbackComponent={ConnectErrorFallback}>
+				<PostDetailContainer id={numId} />
+			</ErrorBoundary>
 		</HydrationBoundary>
 	);
 }

--- a/app/(main)/connect/edit/[id]/page.tsx
+++ b/app/(main)/connect/edit/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 import EditPostContainer from "@/features/connect/containers/EditPostContainer";
 import { getPostDetailServer } from "@/features/connect/apis/getPostDetailServer";
+import { ErrorBoundary } from "react-error-boundary";
+import ConnectErrorFallback from "@/features/connect/components/ErrorBoundary";
 
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
 	const { id: strId } = await params;
@@ -15,7 +17,9 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
 
 	return (
 		<HydrationBoundary state={dehydrate(queryClient)}>
-			<EditPostContainer id={id} />
+			<ErrorBoundary FallbackComponent={ConnectErrorFallback}>
+				<EditPostContainer id={id} />
+			</ErrorBoundary>
 		</HydrationBoundary>
 	);
 }

--- a/app/(main)/connect/error.tsx
+++ b/app/(main)/connect/error.tsx
@@ -1,12 +1,31 @@
 "use client";
 
+// Next.js App Router의 라우트 레벨 에러 핸들러
+// ErrorBoundary로 잡지 못한 예상치 못한 에러의 마지막 안전망
+import { useRouter } from "next/navigation";
+
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
 	console.error(error);
+	const router = useRouter();
 
 	return (
-		<div>
-			<h2>에러 발생</h2>
-			<button onClick={reset}>다시 시도</button>
+		<div className="flex min-h-[50vh] w-full flex-col items-center justify-center gap-3 text-center">
+			<p className="text-base font-semibold text-gray-900">문제가 발생했어요.</p>
+			<p className="text-sm text-gray-500">잠시 후 다시 시도해주세요.</p>
+			<div className="flex gap-2">
+				<button
+					type="button"
+					onClick={() => router.push("/connect")}
+					className="rounded-xl border border-gray-300 px-4 py-2 text-sm text-gray-700">
+					목록으로
+				</button>
+				<button
+					type="button"
+					onClick={reset}
+					className="rounded-xl bg-purple-500 px-4 py-2 text-sm text-white">
+					다시 시도
+				</button>
+			</div>
 		</div>
 	);
 }

--- a/app/(main)/connect/page.tsx
+++ b/app/(main)/connect/page.tsx
@@ -6,8 +6,9 @@ import { Suspense } from "react";
 import { serverFetch } from "@/libs/serverFetch";
 import IntroSection from "@/features/connect/components/IntroSection";
 import { connectQueryKeys } from "@/features/connect/queries";
+import { ErrorBoundary } from "react-error-boundary";
+import ConnectErrorFallback from "@/features/connect/components/ErrorBoundary";
 
-// 서버 컴포넌트
 export default async function ConnectPage({
 	searchParams,
 }: {
@@ -17,7 +18,6 @@ export default async function ConnectPage({
 	const page = Number(pageParam ?? 1);
 
 	const queryClient = new QueryClient();
-
 	const sortBy = "createdAt";
 	const LIMIT = 5;
 
@@ -31,13 +31,8 @@ export default async function ConnectPage({
 					offset: String((page - 1) * LIMIT),
 					limit: String(LIMIT),
 				});
-
 				const res = await serverFetch(`/posts?${queryParams.toString()}`);
-
-				if (!res.ok) {
-					throw new Error("게시글 조회 실패");
-				}
-
+				if (!res.ok) throw new Error("게시글 조회 실패");
 				return res.json();
 			},
 			staleTime: 1000 * 60,
@@ -46,11 +41,7 @@ export default async function ConnectPage({
 			queryKey: connectQueryKeys.hotPosts(),
 			queryFn: async () => {
 				const res = await serverFetch(`/posts?type=best&limit=20`);
-
-				if (!res.ok) {
-					throw new Error("HOT 게시글 조회 실패");
-				}
-
+				if (!res.ok) throw new Error("HOT 게시글 조회 실패");
 				return res.json();
 			},
 			staleTime: 1000 * 60 * 5,
@@ -61,13 +52,17 @@ export default async function ConnectPage({
 		<HydrationBoundary state={dehydrate(queryClient)}>
 			<Container className="min-w-[380px]">
 				<IntroSection />
-				<Suspense fallback={null}>
-					<HotPostSection />
-				</Suspense>
-				<div className="mt-[6.125rem] pb-[8.75rem]">
+				<ErrorBoundary FallbackComponent={ConnectErrorFallback}>
 					<Suspense fallback={null}>
-						<PostContainer />
+						<HotPostSection />
 					</Suspense>
+				</ErrorBoundary>
+				<div className="mt-[6.125rem] pb-[8.75rem]">
+					<ErrorBoundary FallbackComponent={ConnectErrorFallback}>
+						<Suspense fallback={null}>
+							<PostContainer />
+						</Suspense>
+					</ErrorBoundary>
 				</div>
 			</Container>
 		</HydrationBoundary>

--- a/features/connect/components/ErrorBoundary/index.tsx
+++ b/features/connect/components/ErrorBoundary/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { FallbackProps } from "react-error-boundary";
+import { useRouter } from "next/navigation";
+
+export default function ConnectErrorFallback({ resetErrorBoundary }: FallbackProps) {
+	const router = useRouter();
+
+	return (
+		<div className="flex min-h-40 w-full flex-col items-center justify-center gap-3 rounded-3xl bg-white py-10 text-center">
+			<p className="text-base font-semibold text-gray-900">게시글을 불러오지 못했어요</p>
+			<p className="text-sm text-gray-500">잠시 후 다시 시도해주세요</p>
+			<div className="flex gap-2">
+				<button
+					type="button"
+					onClick={() => router.push("/connect")}
+					className="rounded-xl border border-gray-300 px-4 py-2 text-sm text-gray-700">
+					목록으로
+				</button>
+				<button
+					type="button"
+					onClick={resetErrorBoundary}
+					className="rounded-xl bg-purple-500 px-4 py-2 text-sm text-white">
+					다시 시도
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/features/connect/containers/EditPostContainer/index.tsx
+++ b/features/connect/containers/EditPostContainer/index.tsx
@@ -8,6 +8,7 @@ import Container from "@/components/layout/Container";
 import Button from "@/components/ui/Buttons/Button";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/providers/toast-provider";
+import PostCreateSkeleton from "@/features/connect/containers/PostCreateContainer/Skeleton";
 
 export default function EditPostContainer({ id }: { id: number }) {
 	const router = useRouter();
@@ -65,7 +66,7 @@ export default function EditPostContainer({ id }: { id: number }) {
 		);
 	};
 
-	if (!data) return <div>로딩중...</div>;
+	if (!data) return <PostCreateSkeleton />;
 
 	return (
 		<Container narrow>


### PR DESCRIPTION
## 설명
커넥트 페이지 전반에 에러 바운더리를 적용하고, 수정 페이지 로딩 UI를 개선했습니다.

## 변경 사항
- `ConnectErrorFallback` 컴포넌트 신규 추가
  - 에러 메시지 + 목록으로 버튼 + 다시 시도 버튼
- `connect/page.tsx` — `HotPostSection`, `PostContainer` ErrorBoundary 적용
- `connect/[id]/page.tsx` — `PostDetailContainer` ErrorBoundary 적용
- `connect/edit/[id]/page.tsx` — `EditPostContainer` ErrorBoundary 적용
- `EditPostContainer` — 로딩 중 텍스트 → `PostCreateSkeleton` 교체

## 변경 이유

- 에러 발생 시 페이지 전체가 터지는 문제를 방지하고,
- 각 섹션별로 독립적인 에러 처리가 가능하도록 개선했습니다.

## 테스트
- [ ] 게시글 목록 API 실패 시 에러 UI 노출 확인
- [ ] HOT 게시글 API 실패 시 에러 UI 노출 확인
- [ ] 게시글 상세 API 실패 시 에러 UI 노출 확인
- [ ] 게시글 수정 페이지 진입 시 스켈레톤 노출 확인
- [ ] 다시 시도 버튼 클릭 시 재요청 확인
- [ ] 목록으로 버튼 클릭 시 /connect 이동 확인

## 관련 이슈
closes #261


