### PR TITLE
refactor(apis): 이미지 업로드 서버 라우터 추가 및 유효성 검사 이동

### DIFF
--- a/apis/images.ts
+++ b/apis/images.ts
@@ -24,14 +24,14 @@ export interface PresignedUrlResponse {
 }
 
 export const IMAGE_ACCEPT = "image/png, image/jpeg, image/gif, image/webp";
-export const IMAGE_ACCEPTED_EXTS: string[] = IMAGE_ACCEPT.split(", ");
+export const IMAGE_ACCEPTED_TYPES: string[] = IMAGE_ACCEPT.split(", ");
 
 /** 이미지 업로드 */
 export async function uploadImage(file: File) {
 	if (!file) {
 		throw new Error(`파일을 첨부해주세요.`);
 	}
-	if (!IMAGE_ACCEPTED_EXTS.includes(file.type)) {
+	if (!IMAGE_ACCEPTED_TYPES.includes(file.type)) {
 		throw new Error(`'${file.type}'는 지원하지 않는 파일 형식입니다.`);
 	}
 

--- a/apis/images.ts
+++ b/apis/images.ts
@@ -1,11 +1,5 @@
 import { clientFetch } from "@/libs/clientFetch";
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
-
-if (!BASE_URL) {
-	throw new Error("NEXT_PUBLIC_API_URL이 설정되지 않았습니다.");
-}
-
 export interface ErrorResponse {
 	code: string;
 	message: string;
@@ -27,7 +21,7 @@ export const IMAGE_ACCEPT = "image/png, image/jpeg, image/gif, image/webp";
 export const IMAGE_ACCEPTED_TYPES: string[] = IMAGE_ACCEPT.split(", ");
 
 /** 이미지 업로드 */
-export async function uploadImage(file: File) {
+export async function uploadImage(file: File): Promise<string> {
 	if (!file) {
 		throw new Error(`파일을 첨부해주세요.`);
 	}

--- a/apis/images.ts
+++ b/apis/images.ts
@@ -23,60 +23,47 @@ export interface PresignedUrlResponse {
 	publicUrl: string;
 }
 
+export const IMAGE_ACCEPT = "image/png, image/jpeg, image/gif, image/webp";
+export const IMAGE_ACCEPTED_EXTS: string[] = IMAGE_ACCEPT.split(", ");
+
 /** 이미지 업로드 */
-export async function uploadImage(file: File): Promise<string> {
+export async function uploadImage(file: File) {
+	if (!file) {
+		throw new Error(`파일을 첨부해주세요.`);
+	}
+	if (!IMAGE_ACCEPTED_EXTS.includes(file.type)) {
+		throw new Error(`'${file.type}'는 지원하지 않는 파일 형식입니다.`);
+	}
+
 	const { presignedUrl, publicUrl } = await getPresignedUrl(file.name, file.type);
 	await uploadToS3(presignedUrl, file);
 	return publicUrl;
 }
 
 /** 이미지 업로드 Step1: presigned URL 발급 */
-const DEFAULT_ERROR_PRESIGNED = {
-	code: "UNKNOWN_ERROR",
-	message: "이미지 업로드 주소 생성에 실패했습니다.",
-};
 const ROUTE_IMAGES = "/images/presigned";
-async function getPresignedUrl(
-	fileName: string,
-	contentType: string,
-	folder: string = "meetings",
-): Promise<PresignedUrlResponse> {
+async function getPresignedUrl(fileName: string, contentType: string, folder: string = "meetings") {
 	const res = await clientFetch(ROUTE_IMAGES, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ fileName, contentType, folder }),
 	});
 
-	if (!res.ok) {
-		const error: ErrorResponse | ErrorResponsePresigned = await res
-			.json()
-			.catch(() => DEFAULT_ERROR_PRESIGNED);
-		const message =
-			"error" in error
-				? error.error.name === "ZodError"
-					? "파일 형식이 올바르지 않습니다."
-					: error.error.message
-				: error.message;
-		throw new Error(message);
-	}
-	return res.json();
+	const data = await res.json();
+	if (!res.ok) throw new Error(data.message);
+	return data;
 }
 
 /** 이미지 업로드 Step2: S3에 이미지 업로드 */
-async function uploadToS3(presignedUrl: string, file: File): Promise<void> {
-	const res = await fetch(presignedUrl, {
+const ROUTE_IMAGES_UPLOAD = "/images/upload";
+async function uploadToS3(presignedUrl: string, file: File) {
+	const res = await clientFetch(ROUTE_IMAGES_UPLOAD, {
 		method: "PUT",
-		headers: { "Content-Type": file.type },
+		headers: { "Content-Type": file.type, "X-Presigned-Url": presignedUrl },
 		body: file,
 	});
 
-	if (!res.ok) {
-		// 서버 에러 응답이 XML 형식이기 때문에 상태 코드로 분기 처리
-		if (res.status >= 500) {
-			throw new Error("서버에 일시적인 문제가 발생했습니다.");
-		}
-		if (res.status >= 400) {
-			throw new Error("잘못된 요청입니다.");
-		}
-	}
+	const data = await res.json();
+	if (!res.ok) throw new Error(data.message);
+	return data;
 }

--- a/apis/meetingTypes.ts
+++ b/apis/meetingTypes.ts
@@ -7,7 +7,7 @@ if (!BASE_URL) {
 }
 
 const ROUTE_MEETING_TYPES = "/meeting-types";
-export async function getMeetingTypes(): Promise<MeetingTypeResponse> {
+export async function getMeetingTypes() {
 	const res = await fetch(`${BASE_URL}${ROUTE_MEETING_TYPES}`, {
 		method: "GET",
 		headers: { "Content-Type": "application/json" },
@@ -19,7 +19,7 @@ export async function getMeetingTypes(): Promise<MeetingTypeResponse> {
 }
 
 /** layout.tsx 에서 사용. 렌더링 blocking 방지 */
-export async function initMeetingTypes(): Promise<MeetingTypeResponse | null> {
+export async function initMeetingTypes() {
 	try {
 		return await getMeetingTypes();
 	} catch (e) {

--- a/apis/meetingTypes.ts
+++ b/apis/meetingTypes.ts
@@ -6,6 +6,7 @@ if (!BASE_URL) {
 	throw new Error("NEXT_PUBLIC_API_URL이 설정되지 않았습니다.");
 }
 
+/** 모임 카테고리 목록 조회(빌드에서 실행) */
 const ROUTE_MEETING_TYPES = "/meeting-types";
 export async function getMeetingTypes() {
 	const res = await fetch(`${BASE_URL}${ROUTE_MEETING_TYPES}`, {

--- a/apis/meetings.ts
+++ b/apis/meetings.ts
@@ -1,16 +1,10 @@
 import { clientFetch } from "@/libs/clientFetch";
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
-
-if (!BASE_URL) {
-	throw new Error("NEXT_PUBLIC_API_URL이 설정되지 않았습니다.");
-}
-
 const ROUTE_MEETINGS_FAVORITES = (meetingId: number) => `/meetings/${meetingId}/favorites`;
 const ROUTE_MEETINGS_JOIN = (meetingId: number) => `/meetings/${meetingId}/join`;
 
 /** 모임 찜 추가 */
-export async function postMeetingsFavorite({ meetingId }: { meetingId: number }) {
+export async function postMeetingsFavorite({ meetingId }: { meetingId: number }): Promise<void> {
 	const route = ROUTE_MEETINGS_FAVORITES(meetingId);
 	const res = await clientFetch(route, {
 		method: "POST",
@@ -26,7 +20,7 @@ export async function postMeetingsFavorite({ meetingId }: { meetingId: number })
 }
 
 /** 모임 찜 해제 */
-export async function deleteMeetingsFavorite({ meetingId }: { meetingId: number }) {
+export async function deleteMeetingsFavorite({ meetingId }: { meetingId: number }): Promise<void> {
 	const route = ROUTE_MEETINGS_FAVORITES(meetingId);
 	const res = await clientFetch(route, {
 		method: "DELETE",
@@ -42,7 +36,7 @@ export async function deleteMeetingsFavorite({ meetingId }: { meetingId: number 
 }
 
 /** 모임 참여 */
-export async function postMeetingsJoin({ meetingId }: { meetingId: number }) {
+export async function postMeetingsJoin({ meetingId }: { meetingId: number }): Promise<void> {
 	const route = ROUTE_MEETINGS_JOIN(meetingId);
 	const res = await clientFetch(route, {
 		method: "POST",
@@ -58,7 +52,7 @@ export async function postMeetingsJoin({ meetingId }: { meetingId: number }) {
 }
 
 /** 모임 참여 취소 */
-export async function deleteMeetingsJoin({ meetingId }: { meetingId: number }) {
+export async function deleteMeetingsJoin({ meetingId }: { meetingId: number }): Promise<void> {
 	const route = ROUTE_MEETINGS_JOIN(meetingId);
 	const res = await clientFetch(route, {
 		method: "DELETE",

--- a/apis/meetings.ts
+++ b/apis/meetings.ts
@@ -1,5 +1,4 @@
 import { clientFetch } from "@/libs/clientFetch";
-import { MeetupItemResponse } from "@/features/meetup/types";
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -11,11 +10,7 @@ const ROUTE_MEETINGS_FAVORITES = (meetingId: number) => `/meetings/${meetingId}/
 const ROUTE_MEETINGS_JOIN = (meetingId: number) => `/meetings/${meetingId}/join`;
 
 /** 모임 찜 추가 */
-export async function postMeetingsFavorite({
-	meetingId,
-}: {
-	meetingId: number;
-}): Promise<MeetupItemResponse> {
+export async function postMeetingsFavorite({ meetingId }: { meetingId: number }) {
 	const route = ROUTE_MEETINGS_FAVORITES(meetingId);
 	const res = await clientFetch(route, {
 		method: "POST",
@@ -31,11 +26,7 @@ export async function postMeetingsFavorite({
 }
 
 /** 모임 찜 해제 */
-export async function deleteMeetingsFavorite({
-	meetingId,
-}: {
-	meetingId: number;
-}): Promise<SuccessResponse> {
+export async function deleteMeetingsFavorite({ meetingId }: { meetingId: number }) {
 	const route = ROUTE_MEETINGS_FAVORITES(meetingId);
 	const res = await clientFetch(route, {
 		method: "DELETE",
@@ -51,11 +42,7 @@ export async function deleteMeetingsFavorite({
 }
 
 /** 모임 참여 */
-export async function postMeetingsJoin({
-	meetingId,
-}: {
-	meetingId: number;
-}): Promise<SuccessResponse> {
+export async function postMeetingsJoin({ meetingId }: { meetingId: number }) {
 	const route = ROUTE_MEETINGS_JOIN(meetingId);
 	const res = await clientFetch(route, {
 		method: "POST",
@@ -71,11 +58,7 @@ export async function postMeetingsJoin({
 }
 
 /** 모임 참여 취소 */
-export async function deleteMeetingsJoin({
-	meetingId,
-}: {
-	meetingId: number;
-}): Promise<SuccessResponse> {
+export async function deleteMeetingsJoin({ meetingId }: { meetingId: number }) {
 	const route = ROUTE_MEETINGS_JOIN(meetingId);
 	const res = await clientFetch(route, {
 		method: "DELETE",

--- a/app/api/images/presigned/route.ts
+++ b/app/api/images/presigned/route.ts
@@ -1,6 +1,11 @@
-import { serverFetch } from "@/libs/serverFetch";
 import { NextRequest, NextResponse } from "next/server";
+import type { ErrorResponse, ErrorResponsePresigned } from "@/apis/images";
+import { serverFetch } from "@/libs/serverFetch";
 
+const DEFAULT_ERROR_PRESIGNED = {
+	code: "UNKNOWN_ERROR",
+	message: "이미지 업로드 주소 생성에 실패했습니다.",
+};
 /** 이미지 presigned URL 발급 */
 const ROUTE_IMAGES = "/images";
 export async function POST(request: NextRequest) {
@@ -15,8 +20,16 @@ export async function POST(request: NextRequest) {
 		});
 
 		if (!response.ok) {
-			const errorBody = await response.json().catch(() => null);
-			return NextResponse.json(errorBody, { status: response.status });
+			const error: ErrorResponse | ErrorResponsePresigned = await response
+				.json()
+				.catch(() => DEFAULT_ERROR_PRESIGNED);
+			const message =
+				"error" in error
+					? error.error.name === "ZodError"
+						? "파일 형식이 올바르지 않습니다."
+						: error.error.message
+					: error.message;
+			return NextResponse.json({ message }, { status: response.status });
 		}
 
 		const data = await response.json();

--- a/app/api/images/upload/route.ts
+++ b/app/api/images/upload/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function PUT(request: NextRequest) {
+	const presignedUrl = request.headers.get("x-presigned-url");
+	if (!presignedUrl) throw new Error("Missing x-presigned-url header");
+
+	const contentType = request.headers.get("content-type");
+	if (!contentType) throw new Error("Missing content-type header");
+
+	const body = await request.arrayBuffer();
+	const response = await fetch(presignedUrl, {
+		method: "PUT",
+		headers: { "Content-Type": contentType },
+		body: body,
+	});
+
+	if (!response.ok) {
+		// 서버 에러 응답이 XML 형식이기 때문에 상태 코드로 분기 처리
+		if (response.status >= 500) {
+			return NextResponse.json("서버에 일시적인 문제가 발생했습니다.", { status: response.status });
+		}
+		if (response.status >= 400) {
+			return NextResponse.json("잘못된 요청입니다.", { status: response.status });
+		}
+	}
+
+	return NextResponse.json({ success: true });
+}

--- a/app/api/images/upload/route.ts
+++ b/app/api/images/upload/route.ts
@@ -2,10 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(request: NextRequest) {
 	const presignedUrl = request.headers.get("x-presigned-url");
-	if (!presignedUrl) throw new Error("Missing x-presigned-url header");
+	if (!presignedUrl) {
+		return NextResponse.json({ message: "Missing x-presigned-url header" }, { status: 400 });
+	}
 
 	const contentType = request.headers.get("content-type");
-	if (!contentType) throw new Error("Missing content-type header");
+	if (!contentType) {
+		return NextResponse.json({ message: "Missing content-type header" }, { status: 400 });
+	}
 
 	const body = await request.arrayBuffer();
 	const response = await fetch(presignedUrl, {
@@ -17,10 +21,13 @@ export async function PUT(request: NextRequest) {
 	if (!response.ok) {
 		// 서버 에러 응답이 XML 형식이기 때문에 상태 코드로 분기 처리
 		if (response.status >= 500) {
-			return NextResponse.json("서버에 일시적인 문제가 발생했습니다.", { status: response.status });
+			return NextResponse.json(
+				{ message: "서버에 일시적인 문제가 발생했습니다." },
+				{ status: response.status },
+			);
 		}
 		if (response.status >= 400) {
-			return NextResponse.json("잘못된 요청입니다.", { status: response.status });
+			return NextResponse.json({ message: "잘못된 요청입니다." }, { status: response.status });
 		}
 	}
 

--- a/components/ui/Inputs/InputFile/index.tsx
+++ b/components/ui/Inputs/InputFile/index.tsx
@@ -8,6 +8,7 @@ import { IcImagePlus } from "../../icons";
 import DeleteButton from "../../Buttons/DeleteButton";
 import LoaderDots from "../../LoaderDots";
 import useInputImage from "@/hooks/useInputImage";
+import { IMAGE_ACCEPT } from "@/apis/images";
 
 interface InputFileProps extends React.InputHTMLAttributes<HTMLInputElement> {
 	/** 컴포넌트 제어 참조(reset) */
@@ -46,8 +47,6 @@ export interface InputFileHandle {
 	reset: () => void;
 }
 
-export const IMAGE_ACCEPT = "image/png, image/jpeg, image/gif, image/webp";
-export const IMAGE_ACCEPTED_EXTS: string[] = IMAGE_ACCEPT.split(", ");
 const ImageSize = {
 	large: "147px",
 	small: "114px",

--- a/features/meetup/components/FileField/index.tsx
+++ b/features/meetup/components/FileField/index.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useRef } from "react";
-import InputFile, {
-	IMAGE_ACCEPTED_EXTS,
-	type InputFileHandle,
-} from "@/components/ui/Inputs/InputFile";
+import InputFile, { type InputFileHandle } from "@/components/ui/Inputs/InputFile";
 import { useToast } from "@/providers/toast-provider";
 import type { UploadImageFn } from "@/apis/images";
 import { useMutation } from "@tanstack/react-query";
@@ -45,11 +42,6 @@ export default function FileField({
 	function handleUploadImage(e: React.ChangeEvent<HTMLInputElement>) {
 		const file = e.target.files?.[0];
 		if (!file) return;
-
-		if (!IMAGE_ACCEPTED_EXTS.includes(file.type)) {
-			failUpload(`'${file.type}'는 지원하지 않는 파일 형식입니다.`);
-			return;
-		}
 
 		uploadImageMutation.mutate(file, {
 			onSuccess: (data) => {

--- a/features/meetup/queries.ts
+++ b/features/meetup/queries.ts
@@ -12,7 +12,6 @@ import {
 	deleteMeetingsJoin,
 	postMeetingsFavorite,
 	postMeetingsJoin,
-	SuccessResponse,
 } from "@/apis/meetings";
 import { uploadImage } from "@/apis/images";
 import { useUserStore } from "@/store/user.store";
@@ -101,7 +100,7 @@ export function useUploadMeetupImage() {
 }
 
 /** 모임 찜 추가 */
-export function usePostMeetupFavorite(id: number, options?: MutationCallbacks<MeetupItemResponse>) {
+export function usePostMeetupFavorite(id: number, options?: MutationCallbacks<void>) {
 	return useMutation({
 		mutationKey: meetupMutationKeys.postFavorite,
 		mutationFn: () => postMeetingsFavorite({ meetingId: id }),
@@ -110,7 +109,7 @@ export function usePostMeetupFavorite(id: number, options?: MutationCallbacks<Me
 }
 
 /** 모임 찜 해제 */
-export function useDeleteMeetupFavorite(id: number, options?: MutationCallbacks<SuccessResponse>) {
+export function useDeleteMeetupFavorite(id: number, options?: MutationCallbacks<void>) {
 	return useMutation({
 		mutationKey: meetupMutationKeys.deleteFavorite,
 		mutationFn: () => deleteMeetingsFavorite({ meetingId: id }),
@@ -119,7 +118,7 @@ export function useDeleteMeetupFavorite(id: number, options?: MutationCallbacks<
 }
 
 /** 모임 참여 */
-export function usePostMeetupJoin(id: number, options?: MutationCallbacks<SuccessResponse>) {
+export function usePostMeetupJoin(id: number, options?: MutationCallbacks<void>) {
 	return useMutation({
 		mutationKey: meetupMutationKeys.postJoin,
 		mutationFn: () => postMeetingsJoin({ meetingId: id }),
@@ -128,7 +127,7 @@ export function usePostMeetupJoin(id: number, options?: MutationCallbacks<Succes
 }
 
 /** 모임 참여 취소 */
-export function useDeleteMeetupJoin(id: number, options?: MutationCallbacks<SuccessResponse>) {
+export function useDeleteMeetupJoin(id: number, options?: MutationCallbacks<void>) {
 	return useMutation({
 		mutationKey: meetupMutationKeys.deleteJoin,
 		mutationFn: () => deleteMeetingsJoin({ meetingId: id }),


### PR DESCRIPTION
## 🛠️ 설명 (Description)

공통 api 함수 코드에서 일관성을 유지하도록 변경하였습니다.

## 📝 변경 사항 요약 (Summary)

- S3 업로드 API 관련 route handler 추가 및 clientFetch 적용
- 첨부된 이미지 유효성 검사(서버 요청 전)를 api 함수 안으로 이동
- 공통 api 코드에서 불필요한 response 타입 제거

## 💁 변경 사항 이유 (Why)

- 다른 외부 API(카카오 주소 검색)와 달리 route handler가 존재하지 않았음
- 이미지 확장자 유효성 검사가 특정 컴포넌트 안에 작성되어 중복이 발생할 수 있었음
- response 타입으로 인한 코드 재사용성 저하

## 🔗 관련 이슈 (Related Issues)

- Closed #278 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.
