### PR TITLE
refactor(meetupDetail): getQueryClient 적용, Sentry Webhook 커스터마이징

### DIFF
--- a/app/(main)/meetup/[meetupId]/page.tsx
+++ b/app/(main)/meetup/[meetupId]/page.tsx
@@ -1,4 +1,4 @@
-import { dehydrate, HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import {
 	getMeetingDetailServer,
 	getParticipantsServer,
@@ -9,6 +9,7 @@ import { meetupDetailQueryKeys } from "@/features/meetupDetail/queries";
 import MeetupDetailClient from "@/features/meetupDetail/containers/meetupContainer";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { getQueryClient } from "@/libs/getQueryClient";
 
 interface PageProps {
 	params: Promise<{ meetupId: string }>;
@@ -32,6 +33,8 @@ export default async function MeetupDetailPage({ params }: PageProps) {
 	const { meetupId } = await params;
 	const meetingId = Number(meetupId);
 
+	throw new Error("이젠 절대 안할 오류 테스트 발생시키기");
+
 	if (isNaN(meetingId)) notFound();
 	let meeting;
 	try {
@@ -42,7 +45,7 @@ export default async function MeetupDetailPage({ params }: PageProps) {
 
 	if (!meeting) notFound();
 
-	const queryClient = new QueryClient();
+	const queryClient = getQueryClient();
 
 	await Promise.all([
 		queryClient.prefetchQuery({

--- a/app/(main)/meetup/[meetupId]/page.tsx
+++ b/app/(main)/meetup/[meetupId]/page.tsx
@@ -33,8 +33,6 @@ export default async function MeetupDetailPage({ params }: PageProps) {
 	const { meetupId } = await params;
 	const meetingId = Number(meetupId);
 
-	throw new Error("이젠 절대 안할 오류 테스트 발생시키기");
-
 	if (isNaN(meetingId)) notFound();
 	let meeting;
 	try {

--- a/app/api/sentry-webhook/route.ts
+++ b/app/api/sentry-webhook/route.ts
@@ -1,13 +1,141 @@
 import crypto from "crypto";
 import { NextResponse } from "next/server";
+import dayjs from "@/libs/dayjs";
+
+const SENTRY_CLIENT_SECRET = process.env.SENTRY_CLIENT_SECRET;
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+const SENTRY_AUTH_TOKEN = process.env.SENTRY_AUTH_TOKEN;
+const PROJECT_NAME = "REBOOT";
+const SENTRY_ORG_SLUG = "re-boot-4v";
+
+function ellipsis(s: unknown, max = 300) {
+	const str = String(s ?? "");
+	return str.length > max ? `${str.slice(0, max - 1)}...` : str;
+}
+
+function colorByLevel(level?: string) {
+	switch ((level || "").toLowerCase()) {
+		case "fatal":
+			return 0x8e44ad; // 보라
+		case "error":
+			return 0xe74c3c; // 빨강
+		case "warning":
+			return 0xf39c12; // 주황
+		case "info":
+			return 0x3498db; // 파랑
+		case "debug":
+			return 0x95a5a6; // 회색
+		default:
+			return 0x2ecc71; // 초록
+	}
+}
+
+function emojiByLevel(level?: string) {
+	switch ((level || "").toLowerCase()) {
+		case "fatal":
+			return "🟪";
+		case "error":
+			return "🟥";
+		case "warning":
+			return "🟧";
+		case "info":
+			return "🟦";
+		case "debug":
+			return "⬜";
+		default:
+			return "🟩";
+	}
+}
+
+function compactDate(d?: string) {
+	if (!d) return undefined;
+	return dayjs(d).tz("Asia/Seoul").format("YYYY-MM-DD HH:mm:ss");
+}
+
+function pickTopFrame(event: SentryEvent | undefined) {
+	const entry = (event?.entries || []).find((e) => e?.type === "exception");
+	const values = entry?.data?.values || event?.exception?.values || [];
+	const ex = values[values.length - 1] || values[0];
+	const frames = ex?.stacktrace?.frames || [];
+	if (!frames.length) return undefined;
+
+	const frame = [...frames].reverse().find((f) => f?.in_app) || frames[frames.length - 1];
+	const location = [frame?.fileName || frame?.abs_path || "?", frame?.lineno ?? "?"]
+		.filter(Boolean)
+		.join(":");
+
+	const func = frame?.function || "(annoymous)";
+	return { location, func };
+}
+
+function extract(body: SentryWebhookBody) {
+	const issue = body?.data?.issue ?? body?.issue;
+	const event = body?.data?.event ?? body?.event;
+
+	const project = PROJECT_NAME;
+	const level = (event?.level ?? issue?.level ?? "error").toLowerCase();
+	const environment =
+		event?.environment ?? issue?.environment ?? body?.data?.environment ?? "unknown";
+	const release =
+		event?.release ?? event?.contexts?.app?.version ?? issue?.firstRelease?.version ?? undefined;
+	const user = event?.user?.email || event?.user?.username || event?.user?.id || undefined;
+	const shortId = issue?.shortId ?? undefined;
+
+	const issueUrl = issue?.url ?? event?.issue_url ?? event?.web_url ?? undefined;
+	const culprit = event?.culprit ?? issue?.culprit ?? undefined;
+	const message = event?.title ?? event?.message ?? issue?.title ?? "Unknown error";
+
+	const counts = {
+		count: issue?.count ? String(issue.count) : undefined,
+		users: issue?.userCount ? String(issue.userCount) : undefined,
+		firstSeen: compactDate(issue?.firstSeen),
+		lastSeen: compactDate(issue?.lastSeen),
+	};
+	const top = pickTopFrame(event);
+
+	return {
+		project,
+		level,
+		environment,
+		release,
+		user,
+		shortId,
+		issueUrl,
+		culprit,
+		message,
+		counts,
+		top,
+	};
+}
+
+async function fetchIssueData(issueId: string): Promise<IssueData | null> {
+	if (!SENTRY_AUTH_TOKEN) return null;
+	const res = await fetch(
+		`https://sentry.io/api/0/organizations/${SENTRY_ORG_SLUG}/issues/${issueId}/`,
+		{ headers: { Authorization: `Bearer ${SENTRY_AUTH_TOKEN}` } },
+	).catch(() => null);
+	if (!res?.ok) return null;
+	return res.json();
+}
+
+async function postToDiscord(payload: object) {
+	if (!DISCORD_WEBHOOK_URL) throw new Error("DISCORD_WEBHOOK_URL not set");
+	const res = await fetch(DISCORD_WEBHOOK_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const text = await res.text().catch(() => "");
+		throw new Error(`Discord webhook failed: ${res.status} ${text}`);
+	}
+}
 
 export async function POST(req: Request) {
-	const SENTRY_CLIENT_SECRET = process.env.SENTRY_CLIENT_SECRET;
-	const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
-
 	if (!SENTRY_CLIENT_SECRET || !DISCORD_WEBHOOK_URL) {
 		return NextResponse.json(
-			{ error: "SENTRY_CLIENT_SECRET or DISCORD_WEBHOOK_URL not Existed" },
+			{ error: "SENTRY_CLIENT_SECRET or DISCORD_WEBHOOK_URL not set" },
 			{ status: 500 },
 		);
 	}
@@ -38,60 +166,64 @@ export async function POST(req: Request) {
 		);
 	}
 
-	const resource = req.headers.get("sentry-hook-resource");
-	let message;
-
-	if (resource === "event_alert" && body.action === "triggered") {
-		const event = body.data.event;
-		message = {
-			embeds: [
-				{
-					title: `알림: ${event.title}`,
-					description: event.web_url
-						? `[이벤트 ID: ${event.event_id}](${event.web_url})`
-						: event.title,
-					fields: [
-						{
-							name: "프로젝트",
-							value: event.project ? `Project ID: ${event.project}` : "Unknown",
-							inline: true,
-						},
-						{
-							name: "규칙",
-							value: body.data.triggered_rule || "Unknown",
-							inline: true,
-						},
-						{
-							name: "에러 타입",
-							value: event.metadata?.type || "Unknown",
-							inline: true,
-						},
-						{
-							name: "레벨",
-							value: event.level || "Unknown",
-							inline: true,
-						},
-					],
-					color: 0x7566e5,
-				},
-			],
-		};
-	} else {
-		return NextResponse.json({ message: "무시된 이벤트" });
-	}
-
 	try {
-		const response = await fetch(DISCORD_WEBHOOK_URL, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(message),
-		});
-		if (!response.ok) {
-			throw new Error(`웹 훅 전송에 실패했습니다: ${response.status}`);
-		}
-	} catch {
-		return NextResponse.json({ error: "웹 훅 전송에 실패했습니다." }, { status: 500 });
-	}
+		const extracted = extract(body);
+		let { counts } = extracted;
+		const { project, level, environment, release, user, shortId, issueUrl, culprit, message, top } =
+			extracted;
 
-	return NextResponse.json({ message: "웹 훅 전송 완료." });
+		const issueId = body?.data?.event?.issue_id;
+		if (issueId) {
+			const issueData = await fetchIssueData(String(issueId));
+			if (issueData) {
+				counts = {
+					count: issueData.count ? String(issueData.count) : undefined,
+					users: issueData.userCount ? String(issueData.userCount) : undefined,
+					firstSeen: compactDate(issueData.firstSeen),
+					lastSeen: compactDate(issueData.lastSeen),
+				};
+			}
+		}
+
+		const levelEmoji = emojiByLevel(level);
+		const title = shortId
+			? `${levelEmoji} [${project}] ${ellipsis(message, 190)} • ${shortId}`
+			: `${levelEmoji} [${project}] ${ellipsis(message, 220)}`;
+
+		const lines: string[] = [];
+		if (culprit) lines.push(`**원인**: \`${ellipsis(culprit, 180)}\``);
+		if (top) lines.push(`**발생 위치**: \`${ellipsis(`${top.location} · ${top.func}`, 220)}\``);
+		const description = lines.join("\n");
+
+		const fields = [
+			environment && { name: "환경", value: `\`${environment}\``, inline: true },
+			release && { name: "릴리즈(커밋)", value: `\`${ellipsis(release, 8)}\``, inline: true },
+			user && { name: "유저", value: `\`${ellipsis(user, 60)}\``, inline: true },
+			counts.count && { name: "발생 횟수", value: `\`${counts.count}\``, inline: true },
+			counts.users && { name: "영향 유저 수", value: `\`${counts.users}\``, inline: true },
+			counts.firstSeen && { name: "최초 발생", value: `\`${counts.firstSeen}\``, inline: true },
+			issueUrl && { name: "이슈", value: `[Open in Sentry](${issueUrl})`, inline: false },
+		].filter(Boolean) as Array<{ name: string; value: string; inline?: boolean }>;
+
+		const embed = {
+			title,
+			url: issueUrl,
+			description: ellipsis(description, 3900),
+			color: colorByLevel(level),
+			timestamp: new Date().toISOString(),
+			footer: { text: `Sentry → Discord • ${project}` },
+			fields,
+			author: {
+				name: "Sentry Alert",
+				url: issueUrl,
+				icon_url:
+					"https://raw.githubusercontent.com/getsentry/sentry-docs/main/src/images/favicon.png",
+			},
+		};
+		await postToDiscord({ username: "Sentry Bot", embeds: [embed] });
+		return NextResponse.json({ ok: true });
+	} catch (err) {
+		console.error("❌ Sentry Webhook 처리 실패:", err);
+		return new NextResponse("fail", { status: 200 });
+	}
 }

--- a/features/meetupDetail/keys.ts
+++ b/features/meetupDetail/keys.ts
@@ -1,0 +1,29 @@
+/**
+ * meetupDetail query/mutation Key 관리 파일
+ *
+ * 현재는 기존 queries.ts & mutations.tsDML 의 key 선언과 병행 유지합니다.
+ * 추후 팀 전체 key 통합 시, ex) queryKeys.ts로 이동하고,
+ * 기존 선언 및 import 경로를 일괄 변경합니다.
+ * */
+
+export const meetupDetailQueryKeys = {
+	meeting: (meetingId: number) => ["meetupDetail", "meeting", meetingId] as const,
+	participants: (meetingId: number) => ["meetupDetail", "participants", meetingId] as const,
+	reviews: (meetingId: number, cursor?: string) =>
+		["meetupDetail", "reviews", meetingId, cursor] as const,
+	related: {
+		all: () => ["meetupDetail", "related"] as const,
+		detail: (meetingId: number, region: string, type: string) =>
+			["meetupDetail", "related", meetingId, region, type] as const,
+	},
+};
+
+export const meetupDetailMutationKeys = {
+	join: ["meetupDetail", "join", "post"] as const,
+	cancelJoin: ["meetupDetail", "join", "delete"] as const,
+	favorite: ["meetupDetail", "favorite"] as const,
+	editMeeting: ["meetupDetail", "meeting", "patch"] as const,
+	deleteMeeting: ["meetupDetail", "meeting", "delete"] as const,
+	editReview: ["meetupDetail", "review", "patch"] as const,
+	deleteReview: ["meetupDetail", "review", "delete"] as const,
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ export default withSentryConfig(nextConfig, {
 
 	project: "javascript-nextjs",
 
-	authToken: process.env.NEXT_SENTRY_AUTH_TOKEN,
+	authToken: process.env.SENTRY_AUTH_TOKEN,
 
 	// Only print logs for uploading source maps in CI
 	silent: !process.env.CI,

--- a/types/sentry.ts
+++ b/types/sentry.ts
@@ -1,0 +1,73 @@
+interface SentryUser {
+	email?: string;
+	username?: string;
+	id?: string;
+}
+
+interface SentryFrame {
+	fileName?: string;
+	abs_path?: string;
+	lineno?: number;
+	function?: string;
+	in_app?: boolean;
+}
+
+interface SentryException {
+	stacktrace?: { frames: SentryFrame[] };
+}
+
+interface SentryEntry {
+	type: string;
+	data?: { values?: SentryException[] };
+}
+
+interface SentryEvent {
+	level?: string;
+	title?: string;
+	message?: string;
+	environment?: string;
+	release?: string;
+	culprit?: string;
+	user?: SentryUser;
+	tags?: Array<[string, string]> | Record<string, string>;
+	entries?: SentryEntry[];
+	exception?: { values?: SentryException[] };
+	contexts?: { app?: { version?: string } };
+	issue_url?: string;
+	web_url?: string;
+	issue_id?: string;
+}
+
+interface SentryIssue {
+	level?: string;
+	title?: string;
+	environment?: string;
+	shortId?: string;
+	url?: string;
+	culprit?: string;
+	count?: number;
+	userCount?: number;
+	firstSeen?: string;
+	lastSeen?: string;
+	firstRelease?: { version?: string };
+	project?: { name?: string; slug?: string };
+}
+
+interface SentryWebhookBody {
+	data?: {
+		event?: SentryEvent;
+		issue?: SentryIssue;
+		environment?: string;
+	};
+	event?: SentryEvent;
+	issue?: SentryIssue;
+	project?: string;
+	url?: string;
+}
+
+interface IssueData {
+	count?: number;
+	userCount?: number;
+	firstSeen?: string;
+	lastSeen?: string;
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 상세 페이지 서버/클라이언트 데이터 흐름 개선, Sentry Discord 알림 메시지를 커스터마이징했습니다.
또한 `meetupDetail` 도메인의 `query/mutation` key를 분리하여, 유지보수하기 쉬운 형태로 정리했습니다.

## 📄 설계 문서 (Design Document)

## 📝 변경 사항 요약 (Summary)

- 모임 상세 페에지 `SSR QueryClient` 생성 방식을 `new QueryClient()`에서 `getQueryClient()` 기반으로 변경
- Sentry Discord 웹 훅 알림 메시지를 커스터마이징하여 에러 확인 및 대응 효율 향상
- `meetupDetail` 영역의 `query/mutation` key 관리 구조 분리

## 💁 변경 사항 이유 (Why)

- SSR 환경에서 `QueryClient` 관리 방식을 일관되게 유지, 재사용성과 안정성 측면에 유리
- 기본 Discord 알림 메시지만으로는 부족할 수 있어, 정보 추가
- `query/mutation` key를 따로 분리함으로써, 유지보수 향상

## ✅ 테스트 계획 (Test Plan)

- 정상적으로 hydration 되는지 확인
- Sentry 테스트 이벤트 발생 시, 웹훅 메시지가 의도한 형식으로 수신되는지 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #289 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)
현재 `query/mutation` key를 분리해놓았지만, 이전에 import된 경로는 그대로 유지하였습니다. 추후 하나로 통합할 시, 그때 경로 수정 및 중복 코드 삭제할 예정입니다.

## ➕ 추가 정보 (Additional Information)
