### PR TITLE
refactor(reviews): useScrollOnNextQueryChange 훅 추가 

### DIFF
--- a/components/ui/Filter/FilterDropdown/index.tsx
+++ b/components/ui/Filter/FilterDropdown/index.tsx
@@ -35,6 +35,7 @@ export function FilterDropdown({ value, items, onChange }: FilterDropdownProps) 
 					"p-1",
 					"flex flex-col gap-1",
 					"outline-none",
+					"z-10",
 				)}>
 				{items.map((item) => {
 					const selected = value === item.value;

--- a/features/landing/components/Sections/HowItWorksSection/StepCard.tsx
+++ b/features/landing/components/Sections/HowItWorksSection/StepCard.tsx
@@ -23,11 +23,11 @@ export default function StepCard({ steps, activeIndex }: StepCardProps) {
 	const activeStep = steps[activeIndex];
 
 	return (
-		<div className="relative rounded-4xl bg-white p-6 pb-8 shadow-[0_0_20px_0_rgba(0,0,0,0.25)] md:p-8 lg:pb-12 lg:pl-12">
-			<div className="grid items-center gap-6 md:gap-7 lg:grid-cols-[minmax(0,1fr)_592px] lg:gap-12">
-				<div className="relative order-2 lg:order-1">
-					<div className="flex h-full flex-col justify-center">
-						<div className="relative overflow-hidden">
+		<div className="relative w-full rounded-4xl bg-white p-6 pb-8 shadow-[0_0_20px_0_rgba(0,0,0,0.25)] md:p-8 lg:pb-12 lg:pl-12">
+			<div className="grid w-full items-center gap-6 md:gap-7 lg:grid-cols-[minmax(0,1fr)_592px] lg:gap-12">
+				<div className="relative order-2 w-full min-w-0 lg:order-1">
+					<div className="flex h-full w-full flex-col justify-center">
+						<div className="relative w-full overflow-hidden">
 							<motion.div
 								key={`text-${activeStep.id}`}
 								initial={{ x: -32, opacity: 0 }}
@@ -40,13 +40,15 @@ export default function StepCard({ steps, activeIndex }: StepCardProps) {
 									{String(activeStep.id).padStart(2, "0")}
 								</div>
 
-								<p className="mt-6 text-sm text-gray-700 lg:mt-8 lg:text-xl">{activeStep.label}</p>
+								<p className="mt-6 w-full text-sm text-gray-700 lg:mt-8 lg:text-xl">
+									{activeStep.label}
+								</p>
 
 								<h3 className="my-1 text-xl font-bold text-gray-900 md:text-3xl lg:my-4 lg:text-5xl">
 									{activeStep.title}
 								</h3>
 
-								<p className="text-sm text-gray-600 md:text-base lg:text-xl">
+								<p className="text-sm text-gray-600 md:text-base lg:h-15 lg:text-xl">
 									{activeStep.description}
 								</p>
 							</motion.div>
@@ -76,7 +78,7 @@ export default function StepCard({ steps, activeIndex }: StepCardProps) {
 					</div>
 				</div>
 
-				<div className="relative order-1 h-51.5 overflow-hidden rounded-3xl bg-gray-50 md:h-58 lg:order-2 lg:h-[19rem]">
+				<div className="relative order-1 h-51.5 overflow-hidden rounded-3xl bg-gray-50 md:h-58 lg:order-2 lg:h-76">
 					<motion.div
 						key={`image-${activeStep.id}`}
 						className="absolute inset-0"

--- a/features/landing/components/Sections/HowItWorksSection/index.tsx
+++ b/features/landing/components/Sections/HowItWorksSection/index.tsx
@@ -31,14 +31,14 @@ export default function HowItWorksSection() {
 	return (
 		<section ref={sectionRef} className="relative bg-gray-50" style={{ height: sectionHeight }}>
 			<div className="sticky top-0 flex min-h-svh items-center overflow-hidden lg:h-svh">
-				<SectionContainer className="w-full px-6 pt-12.5 pb-17 md:px-12 md:py-20 lg:flex lg:h-svh lg:items-center lg:py-0">
+				<SectionContainer className="w-full px-6 pt-12.5 pb-17 md:px-12 md:py-20 lg:flex lg:h-svh lg:max-w-7xl lg:items-center lg:py-0">
 					<div className="flex w-full flex-col items-center">
 						<SectionHeader
 							title="충전은 이렇게 시작됩니다"
 							description="RE:BOOT와 함께하는 5단계 여정"
 						/>
 
-						<div className="mt-10 md:w-150 lg:mt-14 lg:w-auto">
+						<div className="mt-10 md:w-150 lg:mt-14 lg:w-full">
 							<StepCard steps={HOW_IT_WORKS_STEPS} activeIndex={activeIndex} />
 						</div>
 					</div>

--- a/features/landing/components/Sections/SolutionSection/index.tsx
+++ b/features/landing/components/Sections/SolutionSection/index.tsx
@@ -28,7 +28,7 @@ export default function SolutionSection() {
 					<div>
 						<MotionFadeUp className="flex" delay={0.08}>
 							<span className="text-xl font-bold whitespace-pre-line text-gray-800 md:text-4xl md:text-[40px] md:leading-14">
-								<span className="text-violet-500">RE:BOOT</span>
+								<span className="text-purple-500">RE:BOOT</span>
 								{"는\n당신의 일상을 바꿔주는\n도움을 연결합니다"}
 							</span>
 						</MotionFadeUp>

--- a/features/reviews/components/ListControls/CategoryTabs.tsx
+++ b/features/reviews/components/ListControls/CategoryTabs.tsx
@@ -20,7 +20,7 @@ export default function CategoryTabs({ onWillChange }: CategoryTabsProps) {
 	const type = typeParam ?? "all";
 
 	function handleChangeType(v: string | null) {
-		if (typeParam === v) {
+		if ((typeParam ?? null) === v) {
 			return;
 		}
 

--- a/features/reviews/components/ListControls/CategoryTabs.tsx
+++ b/features/reviews/components/ListControls/CategoryTabs.tsx
@@ -7,14 +7,24 @@ import { useQueryParams } from "@/hooks/useQueryParams";
 import { cn } from "@/utils/cn";
 import { QUERY_PARAM_KEYS } from "../../constants/filers";
 
-export default function CategoryTabs() {
+interface CategoryTabsProps {
+	onWillChange?: () => void;
+}
+
+export default function CategoryTabs({ onWillChange }: CategoryTabsProps) {
 	const { ref, overlays, ...events } = useDragScroll<HTMLUListElement>();
 	const { get, set } = useQueryParams();
 	const { categories } = useCategoryStore();
 
-	const type = get(QUERY_PARAM_KEYS.TYPE) ?? "all";
+	const typeParam = get(QUERY_PARAM_KEYS.TYPE);
+	const type = typeParam ?? "all";
 
 	function handleChangeType(v: string | null) {
+		if (typeParam === v) {
+			return;
+		}
+
+		onWillChange?.();
 		set({ [QUERY_PARAM_KEYS.TYPE]: v });
 	}
 

--- a/features/reviews/components/ListControls/ListFilters.tsx
+++ b/features/reviews/components/ListControls/ListFilters.tsx
@@ -17,15 +17,21 @@ import {
 	REVIEWS_SORT_ORDER_OPTIONS,
 } from "../../constants/filers";
 
-export default function ListFilters() {
+interface ListFiltersProps {
+	onWillChange?: () => void;
+}
+
+export default function ListFilters({ onWillChange }: ListFiltersProps) {
 	const { get, set } = useQueryParams();
 
 	const dateStart = get(QUERY_PARAM_KEYS.DATE_START);
 	const dateEnd = get(QUERY_PARAM_KEYS.DATE_END);
-	const region = getRegionItem(get(QUERY_PARAM_KEYS.REGION));
-	const sortBy = getSortByItem(get(QUERY_PARAM_KEYS.SORT_BY)) ?? REVIEWS_SORT_BY_OPTIONS[0].value;
-	const sortOrder =
-		getSortOrderItem(get(QUERY_PARAM_KEYS.SORT_ORDER)) ?? REVIEWS_SORT_ORDER_OPTIONS[0].value;
+	const regionParam = get(QUERY_PARAM_KEYS.REGION);
+	const sortByParam = get(QUERY_PARAM_KEYS.SORT_BY);
+	const sortOrderParam = get(QUERY_PARAM_KEYS.SORT_ORDER);
+	const region = getRegionItem(regionParam);
+	const sortBy = getSortByItem(sortByParam) ?? REVIEWS_SORT_BY_OPTIONS[0].value;
+	const sortOrder = getSortOrderItem(sortOrderParam) ?? REVIEWS_SORT_ORDER_OPTIONS[0].value;
 
 	const dateRange = {
 		from: dateStart ? dateStart.split("T")[0] : "",
@@ -33,22 +39,46 @@ export default function ListFilters() {
 	};
 
 	function handleChangeDate(value: { from: string; to: string }) {
+		const nextDateStart = value.from || null;
+		const nextDateEnd = value.to || null;
+
+		if ((dateStart ?? null) === nextDateStart && (dateEnd ?? null) === nextDateEnd) {
+			return;
+		}
+
+		onWillChange?.();
 		set({
-			[QUERY_PARAM_KEYS.DATE_START]: value.from || null,
-			[QUERY_PARAM_KEYS.DATE_END]: value.to || null,
+			[QUERY_PARAM_KEYS.DATE_START]: nextDateStart,
+			[QUERY_PARAM_KEYS.DATE_END]: nextDateEnd,
 		});
 	}
 
 	function handleChangeLocation(data: RegionFilterValue) {
 		const param = buildRegionParam(data.region, data.district);
+
+		if (regionParam === param) {
+			return;
+		}
+
+		onWillChange?.();
 		set({ [QUERY_PARAM_KEYS.REGION]: param });
 	}
 
 	function handleChangeSortOrder(v: string) {
+		if (sortOrderParam === v) {
+			return;
+		}
+
+		onWillChange?.();
 		set({ [QUERY_PARAM_KEYS.SORT_ORDER]: v });
 	}
 
 	function handleChangeSortBy(v: string) {
+		if (sortByParam === v) {
+			return;
+		}
+
+		onWillChange?.();
 		set({ [QUERY_PARAM_KEYS.SORT_BY]: v });
 	}
 

--- a/features/reviews/components/ListControls/ListFilters.tsx
+++ b/features/reviews/components/ListControls/ListFilters.tsx
@@ -29,9 +29,10 @@ export default function ListFilters({ onWillChange }: ListFiltersProps) {
 	const regionParam = get(QUERY_PARAM_KEYS.REGION);
 	const sortByParam = get(QUERY_PARAM_KEYS.SORT_BY);
 	const sortOrderParam = get(QUERY_PARAM_KEYS.SORT_ORDER);
+
 	const region = getRegionItem(regionParam);
-	const sortBy = getSortByItem(sortByParam) ?? REVIEWS_SORT_BY_OPTIONS[0].value;
-	const sortOrder = getSortOrderItem(sortOrderParam) ?? REVIEWS_SORT_ORDER_OPTIONS[0].value;
+	const sortBy = getSortByItem(sortByParam);
+	const sortOrder = getSortOrderItem(sortOrderParam);
 
 	const dateRange = {
 		from: dateStart ? dateStart.split("T")[0] : "",
@@ -56,7 +57,7 @@ export default function ListFilters({ onWillChange }: ListFiltersProps) {
 	function handleChangeLocation(data: RegionFilterValue) {
 		const param = buildRegionParam(data.region, data.district);
 
-		if (regionParam === param) {
+		if ((regionParam ?? null) === param) {
 			return;
 		}
 
@@ -65,7 +66,7 @@ export default function ListFilters({ onWillChange }: ListFiltersProps) {
 	}
 
 	function handleChangeSortOrder(v: string) {
-		if (sortOrderParam === v) {
+		if (sortOrder.value === v) {
 			return;
 		}
 
@@ -74,7 +75,7 @@ export default function ListFilters({ onWillChange }: ListFiltersProps) {
 	}
 
 	function handleChangeSortBy(v: string) {
-		if (sortByParam === v) {
+		if (sortBy.value === v) {
 			return;
 		}
 
@@ -89,11 +90,13 @@ export default function ListFilters({ onWillChange }: ListFiltersProps) {
 			className="flex items-center justify-center gap-x-1.5">
 			<DateFilter value={dateRange} onChange={handleChangeDate} />
 			<RegionFilter value={region} onChange={handleChangeLocation} />
+
 			<FilterDropdown
 				value={sortBy.label}
 				items={REVIEWS_SORT_BY_OPTIONS}
 				onChange={handleChangeSortBy}
 			/>
+
 			<FilterDropdown
 				value={sortOrder.label}
 				items={REVIEWS_SORT_ORDER_OPTIONS}

--- a/features/reviews/components/ListControls/index.tsx
+++ b/features/reviews/components/ListControls/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRef } from "react";
+import useScrollOnNextQueryChange from "@/hooks/useScrollOnNextQueryChange";
 import useScrollFloatingVisibility from "@/hooks/useScrollFloatingVisibility";
 import { cn } from "@/utils/cn";
 import CategoryTabs from "./CategoryTabs";
@@ -12,9 +12,10 @@ const MOBILE_STICKY_OFFSET = 48;
 interface ListControlsContentProps {
 	headingId: string;
 	className?: string;
+	onWillChange?: () => void;
 }
 
-function ListControlsContent({ headingId, className }: ListControlsContentProps) {
+function ListControlsContent({ headingId, className, onWillChange }: ListControlsContentProps) {
 	return (
 		<section
 			aria-labelledby={headingId}
@@ -25,41 +26,28 @@ function ListControlsContent({ headingId, className }: ListControlsContentProps)
 			<h2 id={headingId} className="sr-only">
 				리뷰 필터
 			</h2>
-			<CategoryTabs />
-			<ListFilters />
+			<CategoryTabs onWillChange={onWillChange} />
+			<ListFilters onWillChange={onWillChange} />
 		</section>
 	);
 }
 
 export default function ListControls() {
-	const searchParams = useSearchParams();
-	const searchParamsKey = searchParams.toString();
+	const { scrollAnchorRef, markWillChange } = useScrollOnNextQueryChange<HTMLDivElement>();
 	const triggerRef = useRef<HTMLDivElement>(null);
-	const hasMountedRef = useRef(false);
 	const { isVisible, hasPassedThreshold } = useScrollFloatingVisibility({
 		offset: MOBILE_STICKY_OFFSET,
 		triggerRef,
 	});
 	const showMobileFloating = hasPassedThreshold && isVisible;
 
-	useEffect(() => {
-		if (!hasMountedRef.current) {
-			hasMountedRef.current = true;
-			return;
-		}
-
-		triggerRef.current?.scrollIntoView({
-			behavior: "smooth",
-			block: "start",
-		});
-	}, [searchParamsKey]);
-
 	return (
 		<>
+			<div ref={scrollAnchorRef} aria-hidden="true" className="scroll-mt-12 md:scroll-mt-22" />
 			<div
 				ref={triggerRef}
 				className="w-full scroll-mt-12 md:sticky md:top-22 md:z-[9] md:scroll-mt-22 md:bg-gray-50 md:py-3">
-				<ListControlsContent headingId="review-filter-heading" />
+				<ListControlsContent headingId="review-filter-heading" onWillChange={markWillChange} />
 			</div>
 
 			<div
@@ -74,6 +62,7 @@ export default function ListControls() {
 					<ListControlsContent
 						headingId="review-filter-floating-heading"
 						className="pointer-events-auto"
+						onWillChange={markWillChange}
 					/>
 				</div>
 			</div>

--- a/hooks/useScrollOnNextQueryChange.ts
+++ b/hooks/useScrollOnNextQueryChange.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function useScrollOnNextQueryChange<T extends HTMLElement = HTMLDivElement>() {
+	const searchParams = useSearchParams();
+	const searchParamsKey = searchParams.toString();
+	const scrollAnchorRef = useRef<T>(null);
+	const hasMountedRef = useRef(false);
+	const shouldScrollOnNextQueryChangeRef = useRef(false);
+
+	function markWillChange() {
+		shouldScrollOnNextQueryChangeRef.current = true;
+	}
+
+	useEffect(() => {
+		if (!hasMountedRef.current) {
+			hasMountedRef.current = true;
+			return;
+		}
+
+		if (!shouldScrollOnNextQueryChangeRef.current) {
+			return;
+		}
+
+		shouldScrollOnNextQueryChangeRef.current = false;
+
+		scrollAnchorRef.current?.scrollIntoView({
+			behavior: "smooth",
+			block: "start",
+		});
+	}, [searchParamsKey]);
+
+	return { scrollAnchorRef, markWillChange };
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

쿼리 스트링 변화를 감지해 스크롤을 올리는 `useScrollOnNextQueryChange` 훅을 추가했습니다.  
첫 렌더링 시에는 동작하지 않도록 제외 처리했습니다.

그외
랜딩 페이지: sticky 섹션 가로 길이 고정
filter dropdown: z index 추가
하였습니다. 

## 📄 설계 문서 (Design Document)

- 별도 설계 문서 없음

## 📝 변경 사항 요약 (Summary)

- `useScrollOnNextQueryChange` 커스텀 훅 추가
- 쿼리 스트링 변경 시 스크롤 이동 처리
- 첫 렌더링 시 스크롤 이동이 발생하지 않도록 예외 처리
- 스크롤 기준점을 외부에서 `scrollAnchorRef` 로 지정할 수 있도록 구성

## 💁 변경 사항 이유 (Why)

- 첫 진입 시 의도하지 않은 스크롤 이동을 막기 위해
- 쿼리 변경 시에만 스크롤 이동이 일어나도록 제어하기 위해
- 동일한 패턴을 다른 페이지에서도 재사용할 수 있도록 분리하기 위해

## ✅ 테스트 계획 (Test Plan)

- 첫 렌더링 시 스크롤이 이동하지 않는지 확인
- 필터/정렬/페이지 변경 등 쿼리 스트링 변경 시에만 스크롤이 이동하는지 확인
- `markWillChange()` 를 호출하지 않은 쿼리 변경에서는 스크롤이 이동하지 않는지 확인
- `scrollAnchorRef` 를 연결한 DOM 위치를 기준으로 스크롤이 이동하는지 확인

## 🔗 관련 이슈 (Related Issues)

- Related #160

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

### 사용 방법

- 스크롤 기준점이 될 DOM에 `scrollAnchorRef` 를 연결합니다.
- 쿼리 값을 바꾸기 직전에 `markWillChange()` 를 호출합니다.
- 이후 실제로 쿼리 스트링이 변경되면, 연결된 DOM 위치를 기준으로 스크롤이 이동합니다.
- 첫 렌더링 시에는 동작하지 않습니다.

```tsx
const { scrollAnchorRef, markWillChange } = useScrollOnNextQueryChange();

function handleChange() {
	markWillChange();
	router.push(...);
}

return (
	<>
		<div ref={scrollAnchorRef} />
		...
	</>
);