### PR TITLE
refactor(mypage): 마이페이지 api 변경 및 리팩토링

### DIFF
--- a/app/api/users/me/meetings/route.ts
+++ b/app/api/users/me/meetings/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serverFetch } from "@/libs/serverFetch";
+import { nextJsonResponse } from "@/utils/api.server";
+
+// 내가 참여한 / 만든 모임 목록
+export async function GET(request: NextRequest) {
+	try {
+		const endpoint = `/users/me/meetings${request.nextUrl.search}`;
+
+		const res = await serverFetch(endpoint);
+		return nextJsonResponse(res);
+	} catch {
+		return NextResponse.json({ message: "서버 오류가 발생했습니다." }, { status: 500 });
+	}
+}

--- a/components/common/ErrorPage/index.tsx
+++ b/components/common/ErrorPage/index.tsx
@@ -2,12 +2,14 @@
 
 import Button from "@/components/ui/Buttons/Button";
 import Empty from "@/components/ui/Empty";
+import { cn } from "@/utils/cn";
 
 type ErrorPageProps = {
 	onRetryAction: () => void;
 	prefix?: string;
 	title?: string;
 	description?: string;
+	className?: string;
 };
 
 export default function ErrorPage({
@@ -15,14 +17,15 @@ export default function ErrorPage({
 	prefix,
 	title = "불러오지 못했습니다.",
 	description = "잠시 후 다시 시도해주세요. \n 문제가 계속되면 새로고침 후 다시 확인해주세요.",
+	className,
 }: ErrorPageProps) {
 	return (
-		<Empty>
-			<p>
+		<Empty className={cn("min-h-[50vh] w-full", className)}>
+			<p className="mb-4 text-lg font-semibold text-gray-800">
 				{prefix}
 				{title}
 			</p>
-			<p>{description}</p>
+			<p className="whitespace-pre-line">{description}</p>
 			<Button sizes="small" className="mx-auto mt-4 w-30" onClick={onRetryAction}>
 				다시 시도
 			</Button>

--- a/components/ui/Badges/index.tsx
+++ b/components/ui/Badges/index.tsx
@@ -1,6 +1,12 @@
 import { cn } from "@/utils/cn";
 
-type BadgeVariant = "scheduled" | "pending" | "completed" | "confirmed" | "completedAlt";
+type BadgeVariant =
+	| "scheduled"
+	| "pending"
+	| "completed"
+	| "confirmed"
+	| "completedAlt"
+	| "reviewed";
 
 interface BadgeProps {
 	children: React.ReactNode;
@@ -14,6 +20,7 @@ const variantStyles: Record<BadgeVariant, string> = {
 	completed: "bg-gray-100 text-gray-600 font-medium",
 	confirmed: "border-gradient-purple border pl-2 pr-3 gap-0.5",
 	completedAlt: "bg-linear-to-r from-purple-100 to-purple-200 text-gray-600 font-medium",
+	reviewed: "bg-linear-to-r from-green-100 to-green-200 text-green-600 font-medium",
 };
 
 export function Badge({ children, variant = "scheduled", className }: BadgeProps) {

--- a/components/ui/Dropdowns/ActionDropdown/index.tsx
+++ b/components/ui/Dropdowns/ActionDropdown/index.tsx
@@ -1,8 +1,9 @@
+"use client";
 import { cn } from "@/utils/cn";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { cva } from "class-variance-authority";
 import Image from "next/image";
-import type { ButtonHTMLAttributes } from "react";
+import { useEffect, type ButtonHTMLAttributes } from "react";
 import { IcMeetBalls } from "../../icons";
 
 const menuVariants = cva(
@@ -35,6 +36,20 @@ const itemVariants = cva(
 	},
 );
 
+function OpenState({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange?: (open: boolean) => void;
+}) {
+	useEffect(() => {
+		onOpenChange?.(open);
+	}, [open, onOpenChange]);
+
+	return null;
+}
+
 export type ActionDropdownItem = {
 	label: string;
 	onClick: () => void;
@@ -51,6 +66,7 @@ interface ActionDropdownProps extends Omit<ButtonHTMLAttributes<HTMLButtonElemen
 	triggerType?: "actions" | "profile";
 	actionsSize?: "md" | "lg" | "xl";
 	profileImage?: string | null;
+	onOpenChange?: (open: boolean) => void;
 }
 
 export default function ActionDropdown({
@@ -63,6 +79,7 @@ export default function ActionDropdown({
 	actionsSize = "md",
 	profileImage,
 	type,
+	onOpenChange,
 	...props
 }: ActionDropdownProps) {
 	const ariaLabel = triggerType === "profile" ? "프로필 메뉴 열기" : "액션 메뉴 열기";
@@ -71,46 +88,52 @@ export default function ActionDropdown({
 
 	return (
 		<Menu as="div" className={cn("relative inline-block", className)}>
-			<MenuButton
-				type={type ?? "button"}
-				className={cn("cursor-pointer outline-none", triggerClassName)}
-				{...props}>
-				<span className="sr-only">{ariaLabel}</span>
+			{({ open }) => (
+				<>
+					<OpenState open={open} onOpenChange={onOpenChange} />
 
-				{triggerType === "profile" ? (
-					<Image
-						src={profileImageSrc}
-						alt="프로필 이미지"
-						width={42}
-						height={42}
-						className="size-10.5 rounded-full border border-gray-200 object-cover"
-					/>
-				) : (
-					<IcMeetBalls size={actionsSize} className={actionsIconClassName} />
-				)}
-			</MenuButton>
+					<MenuButton
+						type={type ?? "button"}
+						className={cn("cursor-pointer outline-none", triggerClassName)}
+						{...props}>
+						<span className="sr-only">{ariaLabel}</span>
 
-			<MenuItems
-				transition
-				anchor="bottom end"
-				className={cn(menuVariants(), "mt-2 p-1", menuClassName)}>
-				{items.map((item, index) => (
-					<MenuItem
-						key={`${item.label}-${index}`}
-						as="button"
-						type="button"
-						onClick={item.onClick}
-						disabled={item.disabled}
-						className={cn(
-							itemVariants({
-								danger: item.danger,
-							}),
-							item.className,
-						)}>
-						{item.label}
-					</MenuItem>
-				))}
-			</MenuItems>
+						{triggerType === "profile" ? (
+							<Image
+								src={profileImageSrc}
+								alt="프로필 이미지"
+								width={42}
+								height={42}
+								className="size-10.5 rounded-full border border-gray-200 object-cover"
+							/>
+						) : (
+							<IcMeetBalls size={actionsSize} className={actionsIconClassName} />
+						)}
+					</MenuButton>
+
+					<MenuItems
+						transition
+						anchor="bottom end"
+						className={cn(menuVariants(), "mt-2 p-1", menuClassName)}>
+						{items.map((item, index) => (
+							<MenuItem
+								key={`${item.label}-${index}`}
+								as="button"
+								type="button"
+								onClick={item.onClick}
+								disabled={item.disabled}
+								className={cn(
+									itemVariants({
+										danger: item.danger,
+									}),
+									item.className,
+								)}>
+								{item.label}
+							</MenuItem>
+						))}
+					</MenuItems>
+				</>
+			)}
 		</Menu>
 	);
 }

--- a/features/header/components/Notification/index.tsx
+++ b/features/header/components/Notification/index.tsx
@@ -19,7 +19,7 @@ export default function Notification() {
 
 	return (
 		<Popover className="relative leading-0">
-			<PopoverButton className={POPOVER_STYLE.popoverButton}>
+			<PopoverButton className={POPOVER_STYLE.popoverButton} aria-label="알람">
 				{unreadCount > 0 ? <IcBellUnreadOutline /> : <IcBellOutline />}
 			</PopoverButton>
 

--- a/features/header/mutations.ts
+++ b/features/header/mutations.ts
@@ -9,6 +9,8 @@ import { useToast } from "@/providers/toast-provider";
 import { headerQueryKeys } from "./queries";
 import { CursorPageResponse, NotificationCardList } from "./types";
 
+const notificationQueryKey = headerQueryKeys.notification.all;
+
 export function usePutNotificationsReadAll() {
 	const queryClient = useQueryClient();
 	const { handleShowToast } = useToast();
@@ -21,7 +23,7 @@ export function usePutNotificationsReadAll() {
 				message: "모든 알림을 읽었습니다.",
 				status: "success",
 			});
-			queryClient.invalidateQueries({ queryKey: headerQueryKeys.notifications });
+			queryClient.invalidateQueries({ queryKey: notificationQueryKey });
 		},
 
 		onError: () => {
@@ -41,7 +43,7 @@ export function usePutNotificationsRead() {
 		mutationFn: putNotificationsRead,
 
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: headerQueryKeys.notifications });
+			queryClient.invalidateQueries({ queryKey: notificationQueryKey });
 		},
 
 		onError: () => {
@@ -65,7 +67,7 @@ export function useDeleteNotificationsAll() {
 				message: "전체 알림이 삭제되었습니다.",
 				status: "success",
 			});
-			queryClient.invalidateQueries({ queryKey: headerQueryKeys.notifications });
+			queryClient.invalidateQueries({ queryKey: notificationQueryKey });
 		},
 
 		onError: () => {
@@ -87,16 +89,17 @@ export function useDeleteNotifications() {
 
 		onMutate: async ({ notificationId }) => {
 			// 진행중인 refetch 취소
-			await queryClient.cancelQueries({ queryKey: headerQueryKeys.notifications });
+			await queryClient.cancelQueries({ queryKey: notificationQueryKey });
 			// 실패시 롤백용으로 현재 캐시 저장
-			const prevData = queryClient.getQueryData<
-				InfiniteData<CursorPageResponse<NotificationCardList>>
-			>(headerQueryKeys.notifications);
+			const prevData =
+				queryClient.getQueryData<InfiniteData<CursorPageResponse<NotificationCardList>>>(
+					notificationQueryKey,
+				);
 
 			// 캐시에서 해당 알림 제거
 			if (prevData) {
 				queryClient.setQueryData<InfiniteData<CursorPageResponse<NotificationCardList>>>(
-					headerQueryKeys.notifications,
+					notificationQueryKey,
 					{
 						...prevData,
 						pages: prevData.pages.map((page) => ({
@@ -114,12 +117,12 @@ export function useDeleteNotifications() {
 				message: "알림이 삭제되었습니다.",
 				status: "success",
 			});
-			queryClient.invalidateQueries({ queryKey: headerQueryKeys.notifications });
+			queryClient.invalidateQueries({ queryKey: notificationQueryKey });
 		},
 
 		onError: (_error, _variables, context) => {
 			if (context?.prevData) {
-				queryClient.setQueryData(headerQueryKeys.notifications, context.prevData);
+				queryClient.setQueryData(notificationQueryKey, context.prevData);
 			}
 			handleShowToast({
 				message: "알림 삭제에 실패했습니다.\n잠시 후 다시 시도해주세요.",

--- a/features/header/queries.ts
+++ b/features/header/queries.ts
@@ -2,10 +2,17 @@ import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { getFavoritesCount, getNotifications, getNotificationUnreadCount } from "./apis";
 import { useUserStore } from "@/store/user.store";
 
+const HEADER_QUERY_BASE_KEY = ["header"] as const;
 export const headerQueryKeys = {
 	// 찜 개수
-	all: ["header"] as const,
-	favorites: ["header", "favorites"] as const,
+	all: HEADER_QUERY_BASE_KEY,
+	favorites: [...HEADER_QUERY_BASE_KEY, "favorites"] as const,
+	notification: {
+		all: [...HEADER_QUERY_BASE_KEY, "notifications"] as const,
+		count: [...HEADER_QUERY_BASE_KEY, "notifications", "count"] as const,
+	},
+
+	// @TODO 삭제예정 legacy
 	notifications: ["header", "notifications"] as const,
 	notificationsCount: ["header", "notifications", "count"] as const,
 } as const;

--- a/features/mypage/AvailableReviewList/index.tsx
+++ b/features/mypage/AvailableReviewList/index.tsx
@@ -47,7 +47,7 @@ function AvailableReviewList() {
 			{ onSuccess: closeReviewModal, onError: closeReviewModal },
 		);
 	}
-	if (items.length === 0) return <Empty>아직 참여한 모임이 없어요</Empty>;
+	if (items.length === 0) return <Empty>작성 가능한 리뷰가 없어요</Empty>;
 
 	return (
 		<>

--- a/features/mypage/CreatedMeetingList/index.tsx
+++ b/features/mypage/CreatedMeetingList/index.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { Suspense, useRef, useState } from "react";
 import DetailCard from "../components/DetailCard";
-import { DetailCardBadge } from "@/features/mypage/types";
-import { CreatedItem } from "@/features/mypage/types";
+import { MeetupDetailItem } from "@/features/mypage/types";
 import Alert from "@/components/ui/Modals/AlertModal";
 import useMeetingFavorite from "@/hooks/useMeetingFavorite";
 import Empty from "@/components/ui/Empty";
@@ -10,29 +9,27 @@ import { useMyCreatedInfinite } from "../queries";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import Loading from "@/components/ui/Loading";
 import DetailCardSkeleton from "../components/DetailCard/DetailCardSkeleton";
-import { useDeleteMeetings } from "../mutations";
+import { useDeleteMeetings, usePatchMeetingsStatus, usePostMeetingsReviews } from "../mutations";
 import QueryErrorBoundary from "@/components/common/QueryErrorBoundary";
-
-// 모임 배지 상태
-function meetupBadges(item: CreatedItem): DetailCardBadge[] {
-	if (item.canceledAt) {
-		return [{ label: "개설 취소", variant: "completedAlt" }];
-	}
-	if (item.isCompleted) {
-		return [{ label: "이용 완료", variant: "completed" }];
-	}
-	if (item.confirmedAt) {
-		return [{ label: "개설확정", variant: "confirmed", showStatusLabel: true }];
-	}
-
-	return [{ label: "개설 대기", variant: "pending" }];
-}
+import {
+	ALERT_MESSAGE,
+	getHostMeetupActions,
+	HostAlertActionType,
+	MeetupActionHandlers,
+	meetupBadges,
+} from "../utils";
+import ReviewModal, { ReviewFormValues } from "@/features/shared/components/ReviewModal";
 
 function CreatedMeetingList() {
 	const { handleWishToggle } = useMeetingFavorite();
-	// 어떤 모임에 대해 alert을 띄웠는지 타겟팅
-	const [alertTarget, setAlertTarget] = useState<CreatedItem | null>(null);
+	// 어떤 모임에 대해 리뷰 모달을 열었는지 추적 후 target의 item만 값 변경 가능
+	const [reviewTarget, setReviewTarget] = useState<MeetupDetailItem | null>(null);
+	// 어떤 모임에 대해 alert을 띄웠는지
+	const [alertTarget, setAlertTarget] = useState<MeetupDetailItem | null>(null);
+	// alert이 어떤 행동을 할것인지
+	const [alertAction, setAlertAction] = useState<HostAlertActionType | null>(null);
 
+	//모임 목록 불러오기
 	const {
 		data: meetupData,
 		fetchNextPage,
@@ -40,24 +37,97 @@ function CreatedMeetingList() {
 		isFetchingNextPage,
 	} = useMyCreatedInfinite();
 	const items = meetupData.pages.flatMap((page) => page.data) ?? [];
+
+	// 주최 모임 무한스크롤
 	const observerRef = useRef<HTMLDivElement>(null);
 	useIntersectionObserver({
 		targetRef: observerRef,
 		onIntersect: fetchNextPage,
 		isEnabled: !!hasNextPage && !isFetchingNextPage,
 	});
+	// 모임 상태 변경하기
+	const { mutate: patchMeetingsStatus, isPending: isStatusPending } = usePatchMeetingsStatus();
 
 	// 모임 삭제하기
 	const { mutate: deleteMeetings, isPending: isDeletePending } = useDeleteMeetings();
-	// 모임 삭제 시
-	function handleAlertConfirm() {
-		if (!alertTarget) return;
-		deleteMeetings({ meetingId: alertTarget.id }, { onSuccess: closeAlert, onError: closeAlert });
-	}
+	// 어떤 액션이든 하나라도 pending이면 true
+	const isAlertPending = isStatusPending || isDeletePending;
+
+	// 모임 리뷰 작성하기
+	const { mutate: postMeetingReview, isPending: isMeetingReviewPending } = usePostMeetingsReviews();
 
 	// alert modal 닫기
 	function closeAlert() {
 		setAlertTarget(null);
+		setAlertAction(null);
+	}
+
+	// review modal 닫기
+	function closeReviewModal() {
+		setReviewTarget(null);
+	}
+
+	// DetailCard 버튼 핸들러 - 실제 api 행동이 아닌 alert을 우선 띄움
+	function meetupActionHandlers(
+		item: MeetupDetailItem,
+	): Omit<MeetupActionHandlers, "onCancelReservation"> {
+		return {
+			// 모임 확정하기
+			onConfirmMeetup() {
+				setAlertTarget(item);
+				setAlertAction("confirm");
+			},
+			// 모임 삭제하기
+			onDeleteMeetup() {
+				setAlertTarget(item);
+				setAlertAction("delete");
+			},
+			// 모임 취소하기
+			onCancelMeetup() {
+				setAlertTarget(item);
+				setAlertAction("cancelMeetup");
+			},
+			// 리뷰 작성하기
+			onWriteReview() {
+				setReviewTarget(item);
+			},
+		};
+	}
+
+	// Alert 확인 시 api 연결
+	function handleHostAlertConfirm() {
+		if (!alertTarget || !alertAction) return;
+		const actionHandlers: Record<HostAlertActionType, () => void> = {
+			// 모임 확정
+			confirm: () =>
+				patchMeetingsStatus(
+					{ meetingId: alertTarget.id, status: "CONFIRMED" },
+					{ onSuccess: closeAlert, onError: closeAlert },
+				),
+			// 모임 취소
+			cancelMeetup: () =>
+				patchMeetingsStatus(
+					{ meetingId: alertTarget.id, status: "CANCELED" },
+					{ onSuccess: closeAlert, onError: closeAlert },
+				),
+			// 모임 삭제
+			delete: () =>
+				deleteMeetings(
+					{ meetingId: alertTarget.id },
+					{ onSuccess: closeAlert, onError: closeAlert },
+				),
+		};
+
+		actionHandlers[alertAction]();
+	}
+
+	// 리뷰 제출 시
+	function handleReviewSubmit(reviewFormValues: ReviewFormValues) {
+		if (!reviewTarget) return;
+		postMeetingReview(
+			{ meetingId: reviewTarget.id, reviewFormValues },
+			{ onSuccess: closeReviewModal, onError: closeReviewModal },
+		);
 	}
 
 	if (items.length === 0) return <Empty>아직 내가 만든 모임이 없어요</Empty>;
@@ -66,19 +136,15 @@ function CreatedMeetingList() {
 		<>
 			<ul className="flex flex-col gap-4 lg:gap-6">
 				{items.map((item) => {
+					const handlers = meetupActionHandlers(item);
+
 					return (
 						<DetailCard
 							key={item.id}
 							item={item}
 							badges={meetupBadges(item)}
-							actions={[
-								{
-									label: "모임 삭제하기",
-									variant: "grayBorder",
-									handleCardButtonClick: () => setAlertTarget(item),
-									isDestructive: true,
-								},
-							]}
+							actionDisplay="dropdown"
+							actions={getHostMeetupActions(item, handlers)}
 							wishAction={{
 								isWished: item.isFavorited,
 								isPending: false,
@@ -94,14 +160,23 @@ function CreatedMeetingList() {
 
 			<Alert
 				isOpen={!!alertTarget}
-				isPending={isDeletePending}
+				isPending={isAlertPending}
 				onClose={closeAlert}
-				handleConfirmButton={handleAlertConfirm}>
+				handleConfirmButton={handleHostAlertConfirm}>
 				<span className="text-purple-600">
 					{alertTarget?.name} <br />
 				</span>
-				모임을 삭제하시겠습니까?
+				{alertAction && ALERT_MESSAGE[alertAction]}
+				{alertAction === "cancelMeetup" && <p>취소한 모임은 모임 이용이 불가능 합니다.</p>}
 			</Alert>
+
+			<ReviewModal
+				mode="create"
+				isOpen={!!reviewTarget}
+				onClose={closeReviewModal}
+				handleFormSubmit={handleReviewSubmit}
+				isPending={isMeetingReviewPending}
+			/>
 		</>
 	);
 }

--- a/features/mypage/CreatedMeetingList/index.tsx
+++ b/features/mypage/CreatedMeetingList/index.tsx
@@ -20,7 +20,11 @@ import {
 } from "../utils";
 import ReviewModal, { ReviewFormValues } from "@/features/shared/components/ReviewModal";
 
-function CreatedMeetingList() {
+interface CreatedMeetingListProps {
+	onDropdownOpenChange?: (open: boolean) => void;
+}
+
+function CreatedMeetingList({ onDropdownOpenChange }: CreatedMeetingListProps) {
 	const { handleWishToggle } = useMeetingFavorite();
 	// 어떤 모임에 대해 리뷰 모달을 열었는지 추적 후 target의 item만 값 변경 가능
 	const [reviewTarget, setReviewTarget] = useState<MeetupDetailItem | null>(null);
@@ -144,6 +148,7 @@ function CreatedMeetingList() {
 							item={item}
 							badges={meetupBadges(item)}
 							actionDisplay="dropdown"
+							onDropdownOpenChange={onDropdownOpenChange}
 							actions={getHostMeetupActions(item, handlers)}
 							wishAction={{
 								isWished: item.isFavorited,
@@ -181,11 +186,13 @@ function CreatedMeetingList() {
 	);
 }
 
-export default function CreatedMeetingListWrapper() {
+export default function CreatedMeetingListWrapper({
+	onDropdownOpenChange,
+}: CreatedMeetingListProps) {
 	return (
 		<QueryErrorBoundary prefix="내가 만든 모임을 ">
 			<Suspense fallback={<DetailCardSkeleton />}>
-				<CreatedMeetingList />
+				<CreatedMeetingList onDropdownOpenChange={onDropdownOpenChange} />
 			</Suspense>
 		</QueryErrorBoundary>
 	);

--- a/features/mypage/JoinedMeetingList/index.tsx
+++ b/features/mypage/JoinedMeetingList/index.tsx
@@ -6,7 +6,7 @@ import ReviewModal, { ReviewFormValues } from "@/features/shared/components/Revi
 import { MeetupItem } from "@/features/mypage/types";
 import Alert from "@/components/ui/Modals/AlertModal";
 import useMeetingFavorite from "@/hooks/useMeetingFavorite";
-import { useMyMeetupInfinite } from "@/features/mypage/queries";
+import { useMyJoinedInfinite } from "@/features/mypage/queries";
 import Empty from "@/components/ui/Empty";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import Loading from "@/components/ui/Loading";
@@ -141,7 +141,7 @@ function JoinedMeetingList() {
 		fetchNextPage,
 		hasNextPage,
 		isFetchingNextPage,
-	} = useMyMeetupInfinite();
+	} = useMyJoinedInfinite();
 	const items = meetupData.pages.flatMap((page) => page.data) ?? [];
 
 	// 모임 목록 무한스크롤

--- a/features/mypage/JoinedMeetingList/index.tsx
+++ b/features/mypage/JoinedMeetingList/index.tsx
@@ -1,9 +1,8 @@
 "use client";
 import { Suspense, useRef, useState } from "react";
 import DetailCard from "../components/DetailCard";
-import { DetailCardAction, DetailCardBadge } from "@/features/mypage/types";
+import { MeetupDetailItem } from "@/features/mypage/types";
 import ReviewModal, { ReviewFormValues } from "@/features/shared/components/ReviewModal";
-import { MeetupItem } from "@/features/mypage/types";
 import Alert from "@/components/ui/Modals/AlertModal";
 import useMeetingFavorite from "@/hooks/useMeetingFavorite";
 import { useMyJoinedInfinite } from "@/features/mypage/queries";
@@ -18,122 +17,22 @@ import {
 } from "../mutations";
 import DetailCardSkeleton from "../components/DetailCard/DetailCardSkeleton";
 import QueryErrorBoundary from "@/components/common/QueryErrorBoundary";
-import { useUser } from "@/hooks/useUser";
-interface MeetupActionHandlers {
-	/** 모임 확정 */
-	onConfirmMeetup: () => void;
-	/** 모임 삭제 */
-	onDeleteMeetup: () => void;
-	/** 모임 취소 */
-	onCancelMeetup: () => void;
-	/** 모임 예약 취소 */
-	onCancelReservation: () => void;
-	/** 모임 리뷰 작성 */
-	onWriteReview: () => void;
-}
-
-type AlertAction = "confirm" | "delete" | "cancelMeetup" | "cancelReservation";
-
-// alert 메세지
-const ALERT_MESSAGE = {
-	confirm: "모임을 확정하시겠습니까?",
-	delete: "모임을 삭제하시겠습니까?",
-	cancelMeetup: "모임을 취소하시겠습니까?",
-	cancelReservation: "모임 예약을 취소하시겠습니까?",
-} satisfies Record<AlertAction, string>;
-
-// 모임 배지 상태
-function meetupBadges(item: MeetupItem): DetailCardBadge[] {
-	if (item.isCompleted) {
-		if (item.isReviewed)
-			return [
-				{ label: "이용 완료", variant: "completed" },
-				{ label: "리뷰 작성완료", variant: "completedAlt" },
-			];
-		return [{ label: "이용 완료", variant: "completed" }];
-	}
-
-	if (item.confirmedAt) {
-		return [
-			{ label: "이용 예정", variant: "scheduled" },
-			{ label: "개설확정", variant: "confirmed", showStatusLabel: true },
-		];
-	}
-
-	return [
-		{ label: "이용 예정", variant: "scheduled" },
-		{ label: "개설 대기", variant: "pending" },
-	];
-}
-
-// 모임 상태별 액션
-function meetupActions(
-	item: MeetupItem,
-	userId: number,
-	handlers: MeetupActionHandlers,
-): DetailCardAction[] {
-	const isHost = userId === item.hostId;
-
-	if (item.isCompleted) {
-		if (item.isReviewed) return [];
-		return [
-			{
-				label: "리뷰 작성하기",
-				variant: "purple",
-				handleCardButtonClick: handlers.onWriteReview,
-			},
-		];
-	}
-
-	if (isHost) {
-		if (item.confirmedAt) {
-			return [
-				{
-					label: "모임 삭제하기",
-					variant: "grayBorder",
-					handleCardButtonClick: handlers.onDeleteMeetup,
-					isDestructive: true,
-				},
-				{
-					label: "모임 취소하기",
-					variant: "grayBorder",
-					handleCardButtonClick: handlers.onCancelMeetup,
-				},
-			];
-		}
-		return [
-			{
-				label: "모임 취소하기",
-				variant: "grayBorder",
-				handleCardButtonClick: handlers.onCancelMeetup,
-			},
-			{
-				label: "모임 확정하기",
-				variant: "purple",
-				handleCardButtonClick: handlers.onConfirmMeetup,
-			},
-		];
-	}
-
-	return [
-		{
-			label: "예약 취소하기",
-			variant: "purpleBorder",
-			handleCardButtonClick: handlers.onCancelReservation,
-		},
-	];
-}
+import {
+	ALERT_MESSAGE,
+	AlertActionType,
+	MeetupActionHandlers,
+	meetupActions,
+	meetupBadges,
+} from "../utils";
 
 function JoinedMeetingList() {
-	const { user } = useUser();
-	const userId = user?.id;
 	const { handleWishToggle } = useMeetingFavorite();
 	// 어떤 모임에 대해 리뷰 모달을 열었는지 추적 후 target의 item만 값 변경 가능
-	const [reviewTarget, setReviewTarget] = useState<MeetupItem | null>(null);
+	const [reviewTarget, setReviewTarget] = useState<MeetupDetailItem | null>(null);
 	// 어떤 모임에 대해 alert을 띄웠는지
-	const [alertTarget, setAlertTarget] = useState<MeetupItem | null>(null);
+	const [alertTarget, setAlertTarget] = useState<MeetupDetailItem | null>(null);
 	// alert이 어떤 행동을 할것인지
-	const [alertAction, setAlertAction] = useState<AlertAction | null>(null);
+	const [alertAction, setAlertAction] = useState<AlertActionType | null>(null);
 
 	// 모임 목록 불러오기
 	const {
@@ -179,7 +78,7 @@ function JoinedMeetingList() {
 	}
 
 	// DetailCard 버튼 핸들러 - 실제 api 행동이 아닌 alert을 우선 띄움
-	function meetupActionHandlers(item: MeetupItem): MeetupActionHandlers {
+	function meetupActionHandlers(item: MeetupDetailItem): MeetupActionHandlers {
 		return {
 			// 모임 확정하기
 			onConfirmMeetup() {
@@ -212,7 +111,7 @@ function JoinedMeetingList() {
 	function handleAlertConfirm() {
 		if (!alertTarget || !alertAction) return;
 
-		const actionHandlers: Record<AlertAction, () => void> = {
+		const actionHandlers: Record<AlertActionType, () => void> = {
 			// 모임 확정
 			confirm: () =>
 				patchMeetingsStatus(
@@ -250,7 +149,6 @@ function JoinedMeetingList() {
 			{ onSuccess: closeReviewModal, onError: closeReviewModal },
 		);
 	}
-	if (!userId) return null;
 
 	if (items.length === 0) return <Empty>아직 참여한 모임이 없어요</Empty>;
 	return (
@@ -263,7 +161,8 @@ function JoinedMeetingList() {
 							key={item.id}
 							item={item}
 							badges={meetupBadges(item)}
-							actions={meetupActions(item, userId, handlers)}
+							actionDisplay={item.role === "host" ? "dropdown" : "buttons"}
+							actions={meetupActions(item, handlers)}
 							wishAction={{
 								isWished: item.isFavorited,
 								isPending: false,

--- a/features/mypage/JoinedMeetingList/index.tsx
+++ b/features/mypage/JoinedMeetingList/index.tsx
@@ -25,7 +25,11 @@ import {
 	meetupBadges,
 } from "../utils";
 
-function JoinedMeetingList() {
+interface JoinedMeetingListProps {
+	onDropdownOpenChange?: (open: boolean) => void;
+}
+
+function JoinedMeetingList({ onDropdownOpenChange }: JoinedMeetingListProps) {
 	const { handleWishToggle } = useMeetingFavorite();
 	// 어떤 모임에 대해 리뷰 모달을 열었는지 추적 후 target의 item만 값 변경 가능
 	const [reviewTarget, setReviewTarget] = useState<MeetupDetailItem | null>(null);
@@ -162,6 +166,7 @@ function JoinedMeetingList() {
 							item={item}
 							badges={meetupBadges(item)}
 							actionDisplay={item.role === "host" ? "dropdown" : "buttons"}
+							onDropdownOpenChange={item.role === "host" ? onDropdownOpenChange : undefined}
 							actions={meetupActions(item, handlers)}
 							wishAction={{
 								isWished: item.isFavorited,
@@ -198,11 +203,11 @@ function JoinedMeetingList() {
 		</>
 	);
 }
-export default function JoinedMeetingListWrapper() {
+export default function JoinedMeetingListWrapper({ onDropdownOpenChange }: JoinedMeetingListProps) {
 	return (
 		<QueryErrorBoundary prefix="나의 모임을 ">
 			<Suspense fallback={<DetailCardSkeleton />}>
-				<JoinedMeetingList />
+				<JoinedMeetingList onDropdownOpenChange={onDropdownOpenChange} />
 			</Suspense>
 		</QueryErrorBoundary>
 	);

--- a/features/mypage/MyTab/TabWrapper/index.tsx
+++ b/features/mypage/MyTab/TabWrapper/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import PageTabs from "@/components/ui/PageTabs";
 import { useQueryParams } from "@/hooks/useQueryParams";
 import JoinedMeetingListWrapper from "../../JoinedMeetingList";
@@ -49,6 +49,7 @@ export default function TabWrapper() {
 	const activeTab = isTabId(tabQuery) ? tabQuery : TAB_ITEMS[0].id;
 	const isLg = useMediaQuery(MEDIA_QUERY_LG);
 	const isMd = useMediaQuery(MEDIA_QUERY_MD);
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 	const tabRef = useRef<HTMLDivElement>(null);
 	const contentRef = useRef<HTMLDivElement>(null);
 	const threshold = isLg ? THRESHOLD.lg : isMd ? THRESHOLD.md : THRESHOLD.sm;
@@ -66,14 +67,16 @@ export default function TabWrapper() {
 	}, [tabQuery, set]);
 
 	const tabContents: Record<TabId, React.ReactNode> = {
-		JoinedMeetingList: <JoinedMeetingListWrapper />,
-		CreatedMeetingList: <CreatedMeetingListWrapper />,
+		JoinedMeetingList: <JoinedMeetingListWrapper onDropdownOpenChange={setIsDropdownOpen} />,
+		CreatedMeetingList: <CreatedMeetingListWrapper onDropdownOpenChange={setIsDropdownOpen} />,
 		AvailableReviewList: <AvailableReviewListWrapper />,
-		WrittenReviewList: <WrittenReviewListWrapper />,
+		WrittenReviewList: <WrittenReviewListWrapper onDropdownOpenChange={setIsDropdownOpen} />,
 	};
 
 	// activeTab 변경시 스크롤 초기화
 	useEffect(() => {
+		setIsDropdownOpen(false);
+
 		if (isLg) {
 			contentRef.current?.scrollTo({ top: 0, behavior: "auto" });
 			return;
@@ -111,7 +114,12 @@ export default function TabWrapper() {
 				</div>
 			</div>
 
-			<div ref={contentRef} className="scrollbar pt-6 lg:max-h-[calc(100vh-214px)]">
+			<div
+				ref={contentRef}
+				className={cn(
+					"scrollbar pt-6 lg:max-h-[calc(100vh-214px)] lg:overflow-y-auto",
+					isLg && isDropdownOpen && "lg:overflow-hidden!",
+				)}>
 				{tabContents[activeTab]}
 			</div>
 			<ScrollTopButton

--- a/features/mypage/WrittenReviewList/index.tsx
+++ b/features/mypage/WrittenReviewList/index.tsx
@@ -13,7 +13,11 @@ import { useDeleteReviews, usePatchReviews } from "../mutations";
 import QueryErrorBoundary from "@/components/common/QueryErrorBoundary";
 import { useUser } from "@/hooks/useUser";
 
-function WrittenReviewList() {
+interface WrittenReviewListProps {
+	onDropdownOpenChange?: (open: boolean) => void;
+}
+
+function WrittenReviewList({ onDropdownOpenChange }: WrittenReviewListProps) {
 	const { user } = useUser();
 
 	// 어떤 모임에 대해 alert을 띄웠는지
@@ -92,6 +96,7 @@ function WrittenReviewList() {
 						item={reviewItem}
 						handleEdit={() => handleReviewEdit(reviewItem)}
 						handleDelete={() => setAlertTarget(reviewItem)}
+						onDropdownOpenChange={onDropdownOpenChange}
 					/>
 				))}
 			</ul>
@@ -121,11 +126,11 @@ function WrittenReviewList() {
 		</>
 	);
 }
-export default function WrittenReviewListWrapper() {
+export default function WrittenReviewListWrapper({ onDropdownOpenChange }: WrittenReviewListProps) {
 	return (
 		<QueryErrorBoundary prefix="작성한 리뷰를 ">
 			<Suspense fallback={<ReviewCardSkeleton />}>
-				<WrittenReviewList />
+				<WrittenReviewList onDropdownOpenChange={onDropdownOpenChange} />
 			</Suspense>
 		</QueryErrorBoundary>
 	);

--- a/features/mypage/apis.ts
+++ b/features/mypage/apis.ts
@@ -11,9 +11,10 @@ import {
 	PostReviewPayload,
 	PatchReviewPayload,
 	MeMeetingApiRes,
+	MeetupDetailList,
 } from "@/features/mypage/types";
 import { clientFetch } from "@/libs/clientFetch";
-import { mapJoinedMeeting, mapMeReviews } from "./mapper";
+import { mapJoinedMeeting, mapMeReviews, mapUsersMeMeetings } from "./mapper";
 import { throwApiError } from "@/utils/api";
 
 export interface BaseListParams {
@@ -82,12 +83,11 @@ async function mypageFetch<ApiItem, MappedItem, TParams extends object>(
 // 내가 참여한 모임 목록 or 내가 만든 모임 목록
 export async function getUsersMeMeetings(
 	params: GetUsersMeMeetingsParams = {},
-): Promise<CursorPageResponse<MeetupList>> {
-	console.log("getUsersMeMeetings", params);
-	return mypageFetch<MeMeetingApiRes, MeetupList[number], BaseListParams>(
+): Promise<CursorPageResponse<MeetupDetailList>> {
+	return mypageFetch<MeMeetingApiRes, MeetupDetailList[number], GetUsersMeMeetingsParams>(
 		"/users/me/meetings",
 		params,
-		mapJoinedMeeting,
+		mapUsersMeMeetings,
 	);
 }
 

--- a/features/mypage/apis.ts
+++ b/features/mypage/apis.ts
@@ -4,17 +4,16 @@ import {
 	CursorPageResponse,
 	MeetupList,
 	ReviewList,
-	CreatedList,
 	PatchUserProfilePayload,
 	MeetingJoinedApiRes,
 	MeReviewsApiRes,
-	MeetingsMyApiRes,
 	PatchMeetingStatusParams,
 	PostReviewPayload,
 	PatchReviewPayload,
+	MeMeetingApiRes,
 } from "@/features/mypage/types";
 import { clientFetch } from "@/libs/clientFetch";
-import { mapJoinedMeeting, mapMeetingsMy, mapMeReviews } from "./mapper";
+import { mapJoinedMeeting, mapMeReviews } from "./mapper";
 import { throwApiError } from "@/utils/api";
 
 export interface BaseListParams {
@@ -24,6 +23,12 @@ export interface BaseListParams {
 	size?: number;
 }
 export interface GetMeetingsJoinedParams extends BaseListParams {
+	completed?: boolean;
+	reviewed?: boolean;
+}
+
+export interface GetUsersMeMeetingsParams extends BaseListParams {
+	type?: "joined" | "created";
 	completed?: boolean;
 	reviewed?: boolean;
 }
@@ -74,7 +79,19 @@ async function mypageFetch<ApiItem, MappedItem, TParams extends object>(
 	};
 }
 
-// 내가 참여한 모임 목록 , 작성하지 않은 리뷰 목록
+// 내가 참여한 모임 목록 or 내가 만든 모임 목록
+export async function getUsersMeMeetings(
+	params: GetUsersMeMeetingsParams = {},
+): Promise<CursorPageResponse<MeetupList>> {
+	console.log("getUsersMeMeetings", params);
+	return mypageFetch<MeMeetingApiRes, MeetupList[number], BaseListParams>(
+		"/users/me/meetings",
+		params,
+		mapJoinedMeeting,
+	);
+}
+
+// 작성 가능한 리뷰 목록 (참여한 모든 목록)
 export async function getMeetingsJoined(
 	params: GetMeetingsJoinedParams = {},
 ): Promise<CursorPageResponse<MeetupList>> {
@@ -93,17 +110,6 @@ export async function getUsersMeReviews(
 		"/users/me/reviews",
 		params,
 		mapMeReviews,
-	);
-}
-
-// 내가 만든 모임 목록
-export async function getMeetingsMy(
-	params: BaseListParams = {},
-): Promise<CursorPageResponse<CreatedList>> {
-	return mypageFetch<MeetingsMyApiRes, CreatedList[number], BaseListParams>(
-		"/meetings/my",
-		params,
-		mapMeetingsMy,
 	);
 }
 

--- a/features/mypage/components/DetailCard/index.tsx
+++ b/features/mypage/components/DetailCard/index.tsx
@@ -24,6 +24,7 @@ const STYLE = {
 		"text-xs text-gray-600 after:pl-2.5 after:text-gray-300 after:content-['|'] last:after:hidden sm:text-sm",
 	btnWrapper: "flex justify-end gap-4 ",
 	actionBtn: `h-12 w-fit min-w-[calc(50%-0.5rem)] rounded-xl min-[870px]:min-w-auto lg:min-w-39`,
+	transition: "transition-transform duration-450 ease-out",
 };
 
 const EMPTY_THUMBNAIL_IMAGE = "/assets/img/img_empty_purple.svg";
@@ -50,7 +51,11 @@ export default function DetailCard({
 					alt="모임 대표 이미지"
 					width={343}
 					height={343}
-					className={cn(STYLE.itemImage, !!item.image ? "" : "bg-purple-50 object-scale-down")}
+					className={cn(
+						STYLE.itemImage,
+						STYLE.transition,
+						!!item.image ? "hover:scale-107" : "bg-purple-50 object-scale-down",
+					)}
 				/>
 			</Link>
 			<div className={STYLE.wishBtn}>

--- a/features/mypage/components/DetailCard/index.tsx
+++ b/features/mypage/components/DetailCard/index.tsx
@@ -33,6 +33,7 @@ export default function DetailCard({
 	badges,
 	actions,
 	actionDisplay = "buttons",
+	onDropdownOpenChange,
 	wishAction,
 }: DetailCardProps) {
 	const dropdownItems = actions?.map((action) => ({
@@ -112,6 +113,7 @@ export default function DetailCard({
 										aria-label="모임 관리 옵션 열기"
 										actionsIconClassName="md:size-10"
 										items={dropdownItems}
+										onOpenChange={onDropdownOpenChange}
 									/>
 								)
 							: actions &&

--- a/features/mypage/components/DetailCard/index.tsx
+++ b/features/mypage/components/DetailCard/index.tsx
@@ -12,19 +12,20 @@ import ActionDropdown from "@/components/ui/Dropdowns/ActionDropdown";
 
 const STYLE = {
 	itemBgBox: "relative overflow-hidden rounded-3xl bg-white md:flex md:gap-6 md:rounded-4xl md:p-6",
-	itemImage: "h-39 w-full object-cover md:size-47 md:rounded-3xl",
+	itemImageLink: "relative block h-39 shrink-0 overflow-hidden md:size-46 md:rounded-3xl md:pt-6",
+	itemImage: "w-full object-cover transition-transform duration-450 ease-out",
 	wishBtn: "absolute top-4 right-4 md:top-6 md:right-6",
-	itemWrapper: "flex min-w-0 grow flex-col justify-between gap-3 p-4 md:px-0 md:py-2.5",
+	itemWrapper:
+		"relative flex min-w-0 grow flex-col justify-between gap-3 py-6 px-4 md:px-0 md:py-2.5",
 	itemContent:
-		"flex flex-col gap-5.5  md:justify-between min-[870px]:flex-row min-[870px]:items-center",
+		"flex flex-col gap-5.5 min-[480px]:justify-between min-[480px]:flex-row min-[480px]:items-center",
 	personInfo: "flex items-center gap-2 text-sm",
 	itemInfoList: "mt-1.5 flex flex-wrap gap-2.5 md:mt-2.5",
 	itemInfoLabel: "pr-1.5 text-gray-500",
 	itemInfo:
 		"text-xs text-gray-600 after:pl-2.5 after:text-gray-300 after:content-['|'] last:after:hidden sm:text-sm",
 	btnWrapper: "flex justify-end gap-4 ",
-	actionBtn: `h-12 w-fit min-w-[calc(50%-0.5rem)] rounded-xl min-[870px]:min-w-auto lg:min-w-39`,
-	transition: "transition-transform duration-450 ease-out",
+	actionBtn: `h-12 w-fit rounded-xl md:min-w-auto lg:min-w-39`,
 };
 
 const EMPTY_THUMBNAIL_IMAGE = "/assets/img/img_empty_purple.svg";
@@ -45,15 +46,13 @@ export default function DetailCard({
 
 	return (
 		<li className={STYLE.itemBgBox}>
-			<Link href={`/meetup/${item.id}`} className="shrink-0">
+			<Link href={`/meetup/${item.id}`} className={STYLE.itemImageLink}>
 				<Image
 					src={item.image ?? EMPTY_THUMBNAIL_IMAGE}
 					alt={`${item.name}모임 대표 이미지`}
-					width={343}
-					height={343}
+					fill
 					className={cn(
 						STYLE.itemImage,
-						STYLE.transition,
 						!!item.image ? "hover:scale-107" : "bg-purple-50 object-scale-down",
 					)}
 				/>
@@ -109,7 +108,11 @@ export default function DetailCard({
 							</li>
 						</ul>
 					</div>
-					<div className={STYLE.btnWrapper}>
+					<div
+						className={cn(
+							STYLE.btnWrapper,
+							actionDisplay === "dropdown" ? "absolute top-6 right-4" : "",
+						)}>
 						{actionDisplay === "dropdown"
 							? dropdownItems &&
 								dropdownItems.length > 0 && (

--- a/features/mypage/components/DetailCard/index.tsx
+++ b/features/mypage/components/DetailCard/index.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/utils/cn";
 import { uiFormatDate, uiFormatTime } from "@/utils/date";
 import { DetailCardProps } from "@/features/mypage/types";
 import Link from "next/link";
+import ActionDropdown from "@/components/ui/Dropdowns/ActionDropdown";
 
 const STYLE = {
 	itemBgBox: "relative overflow-hidden rounded-3xl bg-white md:flex md:gap-6 md:rounded-4xl md:p-6",
@@ -27,7 +28,19 @@ const STYLE = {
 
 const EMPTY_THUMBNAIL_IMAGE = "/assets/img/img_empty_purple.svg";
 
-export default function DetailCard({ item, badges, actions, wishAction }: DetailCardProps) {
+export default function DetailCard({
+	item,
+	badges,
+	actions,
+	actionDisplay = "buttons",
+	wishAction,
+}: DetailCardProps) {
+	const dropdownItems = actions?.map((action) => ({
+		label: action.label,
+		onClick: action.handleCardButtonClick,
+		danger: action.isDestructive,
+	}));
+
 	return (
 		<li className={STYLE.itemBgBox}>
 			<Link href={`/meetup/${item.id}`} className="shrink-0">
@@ -91,17 +104,27 @@ export default function DetailCard({ item, badges, actions, wishAction }: Detail
 						</ul>
 					</div>
 					<div className={STYLE.btnWrapper}>
-						{actions &&
-							actions.map((action) => (
-								<Button
-									key={action.label}
-									onClick={action.handleCardButtonClick}
-									colors={action.variant}
-									sizes="smallMedium"
-									className={cn(STYLE.actionBtn, action.isDestructive ? "text-error" : "")}>
-									{action.label}
-								</Button>
-							))}
+						{actionDisplay === "dropdown"
+							? dropdownItems &&
+								dropdownItems.length > 0 && (
+									<ActionDropdown
+										className="leading-0"
+										aria-label="모임 관리 옵션 열기"
+										actionsIconClassName="md:size-10"
+										items={dropdownItems}
+									/>
+								)
+							: actions &&
+								actions.map((action) => (
+									<Button
+										key={action.label}
+										onClick={action.handleCardButtonClick}
+										colors={action.variant}
+										sizes="smallMedium"
+										className={cn(STYLE.actionBtn, action.isDestructive ? "text-error" : "")}>
+										{action.label}
+									</Button>
+								))}
 					</div>
 				</div>
 			</div>

--- a/features/mypage/components/DetailCard/index.tsx
+++ b/features/mypage/components/DetailCard/index.tsx
@@ -48,7 +48,7 @@ export default function DetailCard({
 			<Link href={`/meetup/${item.id}`} className="shrink-0">
 				<Image
 					src={item.image ?? EMPTY_THUMBNAIL_IMAGE}
-					alt="모임 대표 이미지"
+					alt={`${item.name}모임 대표 이미지`}
 					width={343}
 					height={343}
 					className={cn(

--- a/features/mypage/components/ReviewCard/index.tsx
+++ b/features/mypage/components/ReviewCard/index.tsx
@@ -23,7 +23,13 @@ const STYLE = {
 const EMPTY_THUMBNAIL_IMAGE = "/assets/img/img_empty_purple.svg";
 const EMPTY_PROFILE_IMAGE = "/assets/img/img_profile.svg";
 
-export default function ReviewCard({ user, item, handleEdit, handleDelete }: ReviewCardProps) {
+export default function ReviewCard({
+	user,
+	item,
+	handleEdit,
+	handleDelete,
+	onDropdownOpenChange,
+}: ReviewCardProps) {
 	const { contentRef, isExpanded, isOverflow, toggleExpanded } =
 		useExpandableText<HTMLParagraphElement>({
 			content: item.comment,
@@ -50,6 +56,7 @@ export default function ReviewCard({ user, item, handleEdit, handleDelete }: Rev
 							className="leading-0"
 							aria-label="리뷰 옵션 열기"
 							actionsIconClassName="md:size-10"
+							onOpenChange={onDropdownOpenChange}
 							items={[
 								{ label: "수정하기", onClick: handleEdit },
 								{ label: "삭제하기", onClick: handleDelete },

--- a/features/mypage/components/ReviewCard/index.tsx
+++ b/features/mypage/components/ReviewCard/index.tsx
@@ -18,6 +18,7 @@ const STYLE = {
 	profileWrapper: "mt-1.5 flex items-center gap-1.5",
 	profileImage: "size-6 rounded-full border border-gray-200 object-cover",
 	caption: "text-xs text-gray-500 md:text-sm",
+	transition: "transition-transform duration-450 ease-out",
 };
 
 const EMPTY_THUMBNAIL_IMAGE = "/assets/img/img_empty_purple.svg";
@@ -36,7 +37,7 @@ export default function ReviewCard({
 		});
 	return (
 		<li className={STYLE.itemBox}>
-			<Link href={`/meetup/${item.meetingId}`} className="shrink-0 md:pt-6">
+			<Link href={`/meetup/${item.meetingId}`} className="group shrink-0 md:pt-6">
 				<Image
 					src={item.meetingImage ?? EMPTY_THUMBNAIL_IMAGE}
 					alt="모임 대표 이미지"
@@ -44,7 +45,8 @@ export default function ReviewCard({
 					height={343}
 					className={cn(
 						STYLE.itemImage,
-						!!item.meetingImage ? "" : "bg-purple-50 object-scale-down",
+						STYLE.transition,
+						!!item.meetingImage ? "hover:scale-107" : "bg-purple-50 object-scale-down",
 					)}
 				/>
 			</Link>

--- a/features/mypage/components/ReviewCard/index.tsx
+++ b/features/mypage/components/ReviewCard/index.tsx
@@ -11,14 +11,19 @@ import ExpandToggleButton from "@/components/ui/Buttons/ExpandToggleButton";
 
 const STYLE = {
 	itemBox: "flex flex-col gap-3 md:flex-row md:gap-8 group",
-	itemImage: "h-39 w-full rounded-xl object-cover md:size-47 md:rounded-3xl",
+	itemImageLink:
+		"relative h-39 shrink-0 overflow-hidden rounded-xl md:size-46 md:rounded-3xl md:pt-6",
+	itemImage: "w-full object-cover transition-transform duration-450 ease-out",
 	itemWrapper:
 		"flex grow flex-col gap-3 border-b border-gray-200 pb-6 md:py-6 group-last-of-type:border-none",
 	ratingWrapper: "flex w-full items-center justify-between",
 	profileWrapper: "mt-1.5 flex items-center gap-1.5",
 	profileImage: "size-6 rounded-full border border-gray-200 object-cover",
 	caption: "text-xs text-gray-500 md:text-sm",
-	transition: "transition-transform duration-450 ease-out",
+	itemInfoList: "mt-1.5 flex flex-wrap gap-x-2.5 gap-y-2 md:mt-2.5",
+	itemInfoLabel: "pr-1.5 text-gray-500",
+	itemInfo:
+		"text-xs text-gray-600 after:pl-2.5 after:text-gray-300 after:content-['|'] last:after:hidden sm:text-sm",
 };
 
 const EMPTY_THUMBNAIL_IMAGE = "/assets/img/img_empty_purple.svg";
@@ -37,15 +42,13 @@ export default function ReviewCard({
 		});
 	return (
 		<li className={STYLE.itemBox}>
-			<Link href={`/meetup/${item.meetingId}`} className="group shrink-0 md:pt-6">
+			<Link href={`/meetup/${item.meetingId}`} className={STYLE.itemImageLink}>
 				<Image
 					src={item.meetingImage ?? EMPTY_THUMBNAIL_IMAGE}
-					alt="모임 대표 이미지"
-					width={343}
-					height={343}
+					alt={`${item.meetingName}모임 대표 이미지`}
+					fill
 					className={cn(
 						STYLE.itemImage,
-						STYLE.transition,
 						!!item.meetingImage ? "hover:scale-107" : "bg-purple-50 object-scale-down",
 					)}
 				/>
@@ -94,8 +97,18 @@ export default function ReviewCard({
 						/>
 					)}
 				</li>
-				<li className={STYLE.caption}>
-					{item.meetingName} · {item.meetingType}
+				<li>
+					<ul className={STYLE.itemInfoList}>
+						<li className={STYLE.itemInfo}>{item.meetingName}</li>
+						<li className={STYLE.itemInfo}>
+							<span className={STYLE.itemInfoLabel}>카테고리</span>
+							{item.meetingType}
+						</li>
+						<li className={STYLE.itemInfo}>
+							<span className={STYLE.itemInfoLabel}>작성 일시</span>
+							{formatIsoDateWithDots(item.createdAt)}
+						</li>
+					</ul>
 				</li>
 			</ul>
 		</li>

--- a/features/mypage/mapper.test.ts
+++ b/features/mypage/mapper.test.ts
@@ -1,5 +1,5 @@
-import { mapJoinedMeeting, mapMeReviews, toReviewScore } from "./mapper";
-import { mockMeetingJoinedApiRes, mockMeReviewsApiRes } from "./mockData";
+import { mapJoinedMeeting, mapMeReviews, mapUsersMeMeetings, toReviewScore } from "./mapper";
+import { mockMeetingJoinedApiRes, mockMeMeetingApiRes, mockMeReviewsApiRes } from "./mockData";
 
 describe("mypage mapper", () => {
 	describe("toReviewScore() 별점 확인", () => {
@@ -16,6 +16,64 @@ describe("mypage mapper", () => {
 		});
 		test("음수 입력시 에러가 발생한다", () => {
 			expect(() => toReviewScore(-1)).toThrow("잘못된 별점 입니다. : -1");
+		});
+	});
+
+	describe("mapUsersMeMeetings() 필드 확인", () => {
+		test("API 응답을 MeetupDetailItem 형태로 매핑한다", () => {
+			const result = mapUsersMeMeetings(mockMeMeetingApiRes);
+
+			expect(result).toEqual({
+				id: 1000,
+				name: "코딩 스터디",
+				region: "경기 수원시 영통구",
+				dateTime: "2026-03-31T16:05:00.000Z",
+				registrationEnd: "2026-03-31T16:00:00.000Z",
+				capacity: 2,
+				participantCount: 2,
+				image: "https://example.com/host.jpg",
+				canceledAt: null,
+				confirmedAt: null,
+				hostId: 1234,
+				isFavorited: false,
+				isReviewed: false,
+				isCompleted: true,
+				role: "host",
+			});
+		});
+
+		test("mapper에 없는 필드는 포함하지 않는다", () => {
+			const result = mapUsersMeMeetings(mockMeMeetingApiRes);
+
+			expect(result).not.toHaveProperty("teamId");
+			expect(result).not.toHaveProperty("address");
+			expect(result).not.toHaveProperty("host");
+			expect(result).not.toHaveProperty("createdAt");
+			expect(result).not.toHaveProperty("joinedAt");
+		});
+
+		test("이미지가 null이어도 그대로 반환한다", () => {
+			const input = { ...mockMeMeetingApiRes, image: null };
+			const result = mapUsersMeMeetings(input);
+
+			expect(result.image).toBeNull();
+		});
+
+		test("canceledAt과 confirmedAt에 값이 있으면 그대로 반환한다", () => {
+			const input = {
+				...mockMeMeetingApiRes,
+				canceledAt: "2026-03-31T09:41:49.482Z",
+				confirmedAt: "2026-03-31T09:40:02.178Z",
+			};
+			const result = mapUsersMeMeetings(input);
+
+			expect(result.canceledAt).toBe("2026-03-31T09:41:49.482Z");
+			expect(result.confirmedAt).toBe("2026-03-31T09:40:02.178Z");
+		});
+		test("mapJoinedMeeting와 달리 role를 반환한다 ", () => {
+			const result = mapUsersMeMeetings(mockMeMeetingApiRes);
+
+			expect(result.role).toBe("host");
 		});
 	});
 

--- a/features/mypage/mapper.test.ts
+++ b/features/mypage/mapper.test.ts
@@ -137,6 +137,7 @@ describe("mypage mapper", () => {
 				id: 123,
 				score: 5,
 				comment: "함께 공부해서 좋았어요",
+				createdAt: "2026-04-08T06:22:04.892Z",
 				meetingId: 1020,
 				meetingType: "자기계발",
 				meetingName: "코딩 스터디",

--- a/features/mypage/mapper.test.ts
+++ b/features/mypage/mapper.test.ts
@@ -1,6 +1,5 @@
-import { mapJoinedMeeting, mapMeetingsMy, mapMeReviews, toReviewScore } from "./mapper";
-import { mockMeetingJoinedApiRes, mockMeetingsMyApiRes, mockMeReviewsApiRes } from "./mockData";
-import { MeetingsMyApiRes } from "./types";
+import { mapJoinedMeeting, mapMeReviews, toReviewScore } from "./mapper";
+import { mockMeetingJoinedApiRes, mockMeReviewsApiRes } from "./mockData";
 
 describe("mypage mapper", () => {
 	describe("toReviewScore() 별점 확인", () => {
@@ -69,34 +68,6 @@ describe("mypage mapper", () => {
 
 			expect(result.canceledAt).toBe("2026-03-31T09:41:49.482Z");
 			expect(result.confirmedAt).toBe("2026-03-31T09:40:02.178Z");
-		});
-	});
-
-	describe("mapMeetingsMy() 필드 확인", () => {
-		test("API 응답을 CreatedItem 형태로 매핑한다", () => {
-			const result = mapMeetingsMy(mockMeetingsMyApiRes);
-
-			expect(result).toEqual({
-				id: 1000,
-				name: "코딩 스터디",
-				region: "경기 수원시 영통구",
-				dateTime: "2026-03-31T16:05:00.000Z",
-				capacity: 2,
-				participantCount: 2,
-				image: "https://example.com/host.jpg",
-				canceledAt: null,
-				confirmedAt: null,
-				isFavorited: false,
-				isCompleted: true,
-			});
-		});
-
-		test("mapJoinedMeeting에는 있지만 mapMeetingsMy에는 없는 필드가 포함되지 않는다 ", () => {
-			const result = mapMeetingsMy(mockMeetingsMyApiRes);
-
-			expect(result).not.toHaveProperty("registrationEnd");
-			expect(result).not.toHaveProperty("hostId");
-			expect(result).not.toHaveProperty("isReviewed");
 		});
 	});
 

--- a/features/mypage/mapper.ts
+++ b/features/mypage/mapper.ts
@@ -1,12 +1,5 @@
 import { ReviewScore } from "@/types/common";
-import {
-	CreatedItem,
-	MeetingJoinedApiRes,
-	MeetingsMyApiRes,
-	MeetupItem,
-	MeReviewsApiRes,
-	ReviewCardItem,
-} from "./types";
+import { MeetingJoinedApiRes, MeetupItem, MeReviewsApiRes, ReviewCardItem } from "./types";
 
 export function toReviewScore(score: number): ReviewScore {
 	if (score >= 1 && score <= 5) {
@@ -45,21 +38,5 @@ export function mapMeReviews(item: MeReviewsApiRes): ReviewCardItem {
 		meetingName: item.meeting.name,
 		meetingImage: item.meeting.image,
 		meetingDateTime: item.meeting.dateTime,
-	};
-}
-
-export function mapMeetingsMy(item: MeetingsMyApiRes): CreatedItem {
-	return {
-		id: item.id,
-		name: item.name,
-		region: item.region,
-		dateTime: item.dateTime,
-		capacity: item.capacity,
-		participantCount: item.participantCount,
-		image: item.image,
-		isFavorited: item.isFavorited,
-		isCompleted: item.isCompleted,
-		canceledAt: item.canceledAt,
-		confirmedAt: item.confirmedAt,
 	};
 }

--- a/features/mypage/mapper.ts
+++ b/features/mypage/mapper.ts
@@ -1,5 +1,12 @@
 import { ReviewScore } from "@/types/common";
-import { MeetingJoinedApiRes, MeetupItem, MeReviewsApiRes, ReviewCardItem } from "./types";
+import {
+	MeetingJoinedApiRes,
+	MeetupDetailItem,
+	MeetupItem,
+	MeMeetingApiRes,
+	MeReviewsApiRes,
+	ReviewCardItem,
+} from "./types";
 
 export function toReviewScore(score: number): ReviewScore {
 	if (score >= 1 && score <= 5) {
@@ -7,6 +14,25 @@ export function toReviewScore(score: number): ReviewScore {
 	}
 
 	throw new Error(`잘못된 별점 입니다. : ${score}`);
+}
+export function mapUsersMeMeetings(item: MeMeetingApiRes): MeetupDetailItem {
+	return {
+		id: item.id,
+		name: item.name,
+		region: item.region,
+		dateTime: item.dateTime,
+		registrationEnd: item.registrationEnd,
+		capacity: item.capacity,
+		participantCount: item.participantCount,
+		image: item.image,
+		canceledAt: item.canceledAt,
+		confirmedAt: item.confirmedAt,
+		hostId: item.hostId,
+		isFavorited: item.isFavorited,
+		isReviewed: item.isReviewed,
+		isCompleted: item.isCompleted,
+		role: item.role,
+	};
 }
 
 export function mapJoinedMeeting(item: MeetingJoinedApiRes): MeetupItem {

--- a/features/mypage/mapper.ts
+++ b/features/mypage/mapper.ts
@@ -64,5 +64,6 @@ export function mapMeReviews(item: MeReviewsApiRes): ReviewCardItem {
 		meetingName: item.meeting.name,
 		meetingImage: item.meeting.image,
 		meetingDateTime: item.meeting.dateTime,
+		createdAt: item.createdAt,
 	};
 }

--- a/features/mypage/mockData.ts
+++ b/features/mypage/mockData.ts
@@ -1,7 +1,40 @@
-import { UserProfile } from "@/features/mypage/types";
+import { MeMeetingApiRes, UserProfile } from "@/features/mypage/types";
 import { MeetingJoinedApiRes, MeReviewsApiRes } from "./types";
 
 // mock
+export const mockMeMeetingApiRes: MeMeetingApiRes = {
+	id: 1000,
+	teamId: "lucky7",
+	name: "코딩 스터디",
+	type: "문화생활",
+	region: "경기 수원시 영통구",
+	address: "경기 수원시 영통구 원천동 산 5-1, 상세주소",
+	latitude: 37.28295793156606,
+	longitude: 127.0435528563181,
+	dateTime: "2026-03-31T16:05:00.000Z",
+	registrationEnd: "2026-03-31T16:00:00.000Z",
+	capacity: 2,
+	participantCount: 2,
+	image: "https://example.com/host.jpg",
+	description: "함께 공부해요",
+	canceledAt: null,
+	confirmedAt: null,
+	hostId: 1234,
+	createdAt: "2026-03-31T09:41:49.482Z",
+	updatedAt: "2026-03-31T09:42:02.178Z",
+	host: {
+		id: 1234,
+		name: "홍길동",
+		image: "https://example.com/host.jpg",
+	},
+	createdBy: 1234,
+	isFavorited: false,
+	joinedAt: "2026-03-31T09:41:50.024Z",
+	isReviewed: false,
+	isCompleted: true,
+	role: "host",
+};
+
 export const mockMeetingJoinedApiRes: MeetingJoinedApiRes = {
 	id: 1000,
 	teamId: "lucky7",

--- a/features/mypage/mockData.ts
+++ b/features/mypage/mockData.ts
@@ -1,5 +1,5 @@
 import { UserProfile } from "@/features/mypage/types";
-import { MeetingJoinedApiRes, MeetingsMyApiRes, MeReviewsApiRes } from "./types";
+import { MeetingJoinedApiRes, MeReviewsApiRes } from "./types";
 
 // mock
 export const mockMeetingJoinedApiRes: MeetingJoinedApiRes = {
@@ -47,36 +47,6 @@ export const mockMeReviewsApiRes: MeReviewsApiRes = {
 		dateTime: "2026-04-02T16:05:00.000Z",
 	},
 	createdAt: "2026-04-08T06:22:04.892Z",
-};
-
-export const mockMeetingsMyApiRes: MeetingsMyApiRes = {
-	id: 1000,
-	teamId: "lucky7",
-	name: "코딩 스터디",
-	type: "문화생활",
-	region: "경기 수원시 영통구",
-	address: "경기 수원시 영통구 원천동 산 5-1, 상세주소",
-	latitude: 37.28295793156606,
-	longitude: 127.0435528563181,
-	dateTime: "2026-03-31T16:05:00.000Z",
-	registrationEnd: "2026-03-31T16:00:00.000Z",
-	capacity: 2,
-	participantCount: 2,
-	image: "https://example.com/host.jpg",
-	description: "함께 공부해요",
-	canceledAt: null,
-	confirmedAt: null,
-	hostId: 1234,
-	createdAt: "2026-03-31T09:41:49.482Z",
-	updatedAt: "2026-03-31T09:42:02.178Z",
-	host: {
-		id: 1234,
-		name: "홍길동",
-		image: "https://example.com/host.jpg",
-	},
-	createdBy: 1234,
-	isFavorited: false,
-	isCompleted: true,
 };
 
 export const mockUserProfile: UserProfile = {

--- a/features/mypage/mutations.ts
+++ b/features/mypage/mutations.ts
@@ -13,6 +13,8 @@ import { useToast } from "@/providers/toast-provider";
 import { mypageQueryKeys } from "./queries";
 import { meetupDetailQueryKeys } from "../meetupDetail/queries";
 import { headerQueryKeys } from "../header/queries";
+import { meetupQueryKeys } from "../meetup/queries";
+import { reviewsQueryKeys } from "../reviews/queries/queryKeys";
 
 interface UsePatchUsersMeOptions {
 	onSuccessBeforeSync?: () => void;
@@ -80,12 +82,11 @@ export function usePatchMeetingsStatus() {
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.all });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.created });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetup.all });
 			queryClient.invalidateQueries({
 				queryKey: meetupDetailQueryKeys.meeting(variables.meetingId),
 			});
-			queryClient.invalidateQueries({ queryKey: ["meetup", "list"] });
+			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 		},
 
 		onError: (_error, variables) => {
@@ -112,12 +113,11 @@ export function useDeleteMeetings() {
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.all });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.created });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetup.all });
 			queryClient.invalidateQueries({
 				queryKey: meetupDetailQueryKeys.meeting(variables.meetingId),
 			});
-			queryClient.invalidateQueries({ queryKey: ["meetup", "list"] });
+			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 		},
 
 		onError: () => {
@@ -143,15 +143,14 @@ export function useDeleteMeetingsJoin() {
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.all });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.created });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetup.all });
 			queryClient.invalidateQueries({
 				queryKey: meetupDetailQueryKeys.meeting(variables.meetingId),
 			});
 			queryClient.invalidateQueries({
 				queryKey: meetupDetailQueryKeys.participants(variables.meetingId),
 			});
-			queryClient.invalidateQueries({ queryKey: ["meetup", "list"] });
+			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 		},
 
 		onError: () => {
@@ -176,9 +175,9 @@ export function usePostMeetingsReviews() {
 				message: `리뷰가 작성 되었습니다.`,
 				status: "success",
 			});
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.reviews });
-			queryClient.invalidateQueries({ queryKey: ["reviews"] });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetup.all });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.review.all });
+			queryClient.invalidateQueries({ queryKey: reviewsQueryKeys.reviews.all });
 		},
 
 		onError: () => {
@@ -203,9 +202,9 @@ export function usePatchReviews() {
 				message: `리뷰가 수정 되었습니다.`,
 				status: "success",
 			});
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.reviews });
-			queryClient.invalidateQueries({ queryKey: ["reviews"] });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetup.all });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.review.all });
+			queryClient.invalidateQueries({ queryKey: reviewsQueryKeys.reviews.all });
 		},
 
 		onError: () => {
@@ -230,9 +229,9 @@ export function useDeleteReviews() {
 				message: `리뷰가 삭제 되었습니다.`,
 				status: "success",
 			});
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetups });
-			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.reviews });
-			queryClient.invalidateQueries({ queryKey: ["reviews"] });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.meetup.all });
+			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.review.all });
+			queryClient.invalidateQueries({ queryKey: reviewsQueryKeys.reviews.all });
 		},
 
 		onError: () => {

--- a/features/mypage/queries.ts
+++ b/features/mypage/queries.ts
@@ -3,7 +3,8 @@ import {
 	BaseListParams,
 	getMeetingsJoined,
 	GetMeetingsJoinedParams,
-	getMeetingsMy,
+	getUsersMeMeetings,
+	GetUsersMeMeetingsParams,
 	getUsersMeReviews,
 } from "./apis";
 
@@ -13,32 +14,92 @@ const DEFAULT_PARAMS = {
 	size: 10,
 } as const;
 
-const DEFAULT_REVIEW_PARAMS = {
+const WRITTEN_REVIEW_PARAMS = {
+	...DEFAULT_PARAMS,
 	sortBy: "createdAt",
-	sortOrder: "desc",
-	size: 10,
 } as const;
+
+const MYPAGE_QUERY_BASE_KEY = ["mypage"] as const;
 
 export const mypageQueryKeys = {
-	all: ["mypage"] as const,
-	// 참여한 모임 목록 (나의 모임, 작성 가능한 리뷰)
+	all: MYPAGE_QUERY_BASE_KEY,
+
+	meetup: {
+		all: [...MYPAGE_QUERY_BASE_KEY, "meetups"] as const,
+		joined: [...MYPAGE_QUERY_BASE_KEY, "meetups", "joined"] as const,
+		joinedList: (params: GetUsersMeMeetingsParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "meetups", "joined", params] as const,
+
+		created: [...MYPAGE_QUERY_BASE_KEY, "meetups", "created"] as const,
+		createdList: (params: GetUsersMeMeetingsParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "meetups", "created", params] as const,
+	},
+
+	review: {
+		all: [...MYPAGE_QUERY_BASE_KEY, "reviews"] as const,
+		available: [...MYPAGE_QUERY_BASE_KEY, "reviews", "available"] as const,
+		availableList: (params: GetMeetingsJoinedParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "reviews", "available", params] as const,
+
+		written: [...MYPAGE_QUERY_BASE_KEY, "reviews", "written"] as const,
+		writtenList: (params: BaseListParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "reviews", "written", params] as const,
+	},
+
+	// @TODO 삭제예정 legacy
 	meetups: ["mypage", "meetups"] as const,
 	meetupsList: (params: GetMeetingsJoinedParams = {}) => ["mypage", "meetups", params] as const,
-	// 작성한 리뷰 목록
+
 	reviews: ["mypage", "reviews"] as const,
 	reviewsList: (params: BaseListParams = {}) => ["mypage", "reviews", params] as const,
-	// 만든 모임 목록
+
 	created: ["mypage", "created"] as const,
-	createdList: (params: BaseListParams = {}) => ["mypage", "created", params] as const,
+	createdList: (params: GetUsersMeMeetingsParams = {}) => ["mypage", "created", params] as const,
 } as const;
 
-// 참여한 모임 목록 (나의 모임, 작성 가능한 리뷰)
+// 내가 참여한 모임 목록
+export function useMyJoinedInfinite(params: Omit<GetUsersMeMeetingsParams, "cursor"> = {}) {
+	const mergedParams = { ...DEFAULT_PARAMS, ...params, type: "joined" as const };
+
+	return useSuspenseInfiniteQuery({
+		queryKey: mypageQueryKeys.meetup.joinedList(mergedParams),
+		queryFn: ({ pageParam }) =>
+			getUsersMeMeetings({
+				...mergedParams,
+				cursor: pageParam,
+			}),
+		getNextPageParam: (lastPage) =>
+			lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
+		initialPageParam: undefined as string | undefined,
+		staleTime: 1000 * 60 * 3,
+	});
+}
+
+// 내가 만든 모임 목록
+export function useMyCreatedInfinite(params: Omit<GetUsersMeMeetingsParams, "cursor"> = {}) {
+	const mergedParams = { ...DEFAULT_PARAMS, ...params, type: "created" as const };
+
+	return useSuspenseInfiniteQuery({
+		queryKey: mypageQueryKeys.meetup.createdList(mergedParams),
+		queryFn: ({ pageParam }) =>
+			getUsersMeMeetings({
+				...mergedParams,
+				cursor: pageParam,
+			}),
+		getNextPageParam: (lastPage) =>
+			lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
+		initialPageParam: undefined as string | undefined,
+		staleTime: 1000 * 60 * 3,
+	});
+}
+
+// 작성 가능한 리뷰
 export function useMyMeetupInfinite(params: Omit<GetMeetingsJoinedParams, "cursor"> = {}) {
 	// 초기값과 외부에서 받은 params를 합침
 	const mergedParams = { ...DEFAULT_PARAMS, ...params };
 
 	return useSuspenseInfiniteQuery({
-		queryKey: mypageQueryKeys.meetupsList(mergedParams),
+		queryKey: mypageQueryKeys.review.availableList(mergedParams),
 		queryFn: ({ pageParam }) =>
 			getMeetingsJoined({
 				...mergedParams,
@@ -57,30 +118,12 @@ export function useMyMeetupInfinite(params: Omit<GetMeetingsJoinedParams, "curso
 
 // 내가 작성한 리뷰 목록 조회
 export function useMyReviewInfinite(params: Omit<BaseListParams, "cursor"> = {}) {
-	const mergedParams = { ...DEFAULT_REVIEW_PARAMS, ...params };
+	const mergedParams = { ...WRITTEN_REVIEW_PARAMS, ...params };
 
 	return useSuspenseInfiniteQuery({
-		queryKey: mypageQueryKeys.reviewsList(mergedParams),
+		queryKey: mypageQueryKeys.review.writtenList(mergedParams),
 		queryFn: ({ pageParam }) =>
 			getUsersMeReviews({
-				...mergedParams,
-				cursor: pageParam,
-			}),
-		getNextPageParam: (lastPage) =>
-			lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
-		initialPageParam: undefined as string | undefined,
-		staleTime: 1000 * 60 * 3,
-	});
-}
-
-// 내가 만든 모임 목록
-export function useMyCreatedInfinite(params: Omit<BaseListParams, "cursor"> = {}) {
-	const mergedParams = { ...DEFAULT_PARAMS, ...params };
-
-	return useSuspenseInfiniteQuery({
-		queryKey: mypageQueryKeys.createdList(mergedParams),
-		queryFn: ({ pageParam }) =>
-			getMeetingsMy({
 				...mergedParams,
 				cursor: pageParam,
 			}),

--- a/features/mypage/queries.ts
+++ b/features/mypage/queries.ts
@@ -14,11 +14,6 @@ const DEFAULT_PARAMS = {
 	size: 10,
 } as const;
 
-const WRITTEN_REVIEW_PARAMS = {
-	...DEFAULT_PARAMS,
-	sortBy: "createdAt",
-} as const;
-
 const MYPAGE_QUERY_BASE_KEY = ["mypage"] as const;
 
 export const mypageQueryKeys = {
@@ -77,7 +72,12 @@ export function useMyJoinedInfinite(params: Omit<GetUsersMeMeetingsParams, "curs
 
 // 내가 만든 모임 목록
 export function useMyCreatedInfinite(params: Omit<GetUsersMeMeetingsParams, "cursor"> = {}) {
-	const mergedParams = { ...DEFAULT_PARAMS, ...params, type: "created" as const };
+	const mergedParams = {
+		...DEFAULT_PARAMS,
+		sortBy: "createdAt" as const,
+		...params,
+		type: "created" as const,
+	};
 
 	return useSuspenseInfiniteQuery({
 		queryKey: mypageQueryKeys.meetup.createdList(mergedParams),
@@ -118,7 +118,7 @@ export function useMyMeetupInfinite(params: Omit<GetMeetingsJoinedParams, "curso
 
 // 내가 작성한 리뷰 목록 조회
 export function useMyReviewInfinite(params: Omit<BaseListParams, "cursor"> = {}) {
-	const mergedParams = { ...WRITTEN_REVIEW_PARAMS, ...params };
+	const mergedParams = { ...DEFAULT_PARAMS, sortBy: "createdAt" as const, ...params };
 
 	return useSuspenseInfiniteQuery({
 		queryKey: mypageQueryKeys.review.writtenList(mergedParams),

--- a/features/mypage/queryKey.ts
+++ b/features/mypage/queryKey.ts
@@ -1,0 +1,58 @@
+import { BaseListParams, GetMeetingsJoinedParams, GetUsersMeMeetingsParams } from "./apis";
+
+/**
+ *
+ * 해당 파일은 현재 사용되지 않으며
+ * 팀 전체 queryKeys 통합을 위해 선언된 파일입니다.
+ * 추후 선언 및 import 경로를 변경합니다.
+ * 임의로 mypage 와 header 를 동일파일에 작성합니다.
+ *
+ * 모임참여,참여취소 등 모임참여 관련한 경우 = meetup.joined
+ * 모임생성,모임변경,모임확정,모임취소,모임삭제 등 모임주최 관련한 경우 = meetup.create
+ * 모임관련해서 나누지않고 meetup.all 도 가능
+ * 리뷰 생성,수정,삭제 등 리뷰 관련한경우 = review.all
+ */
+
+const MYPAGE_QUERY_BASE_KEY = ["mypage"] as const;
+export const mypageQueryKeys = {
+	all: MYPAGE_QUERY_BASE_KEY,
+	meetups: {
+		all: [...MYPAGE_QUERY_BASE_KEY, "meetups"] as const,
+		// 참여한 모임 목록
+		joined: [...MYPAGE_QUERY_BASE_KEY, "meetups", "joined"] as const,
+		joinedList: (params: GetUsersMeMeetingsParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "meetups", "joined", params] as const,
+		// 만든 모임 목록
+		created: [...MYPAGE_QUERY_BASE_KEY, "meetups", "created"] as const,
+		createdList: (params: GetUsersMeMeetingsParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "meetups", "created", params] as const,
+	},
+
+	reviews: {
+		// 작성 가능한 리뷰 목록 (참여한 모든 목록)
+		all: [...MYPAGE_QUERY_BASE_KEY, "reviews"] as const,
+		available: [...MYPAGE_QUERY_BASE_KEY, "reviews", "available"] as const,
+		availableList: (params: GetMeetingsJoinedParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "reviews", "available", params] as const,
+		// 작성한 리뷰 목록
+		written: [...MYPAGE_QUERY_BASE_KEY, "reviews", "written"] as const,
+		writtenList: (params: BaseListParams = {}) =>
+			[...MYPAGE_QUERY_BASE_KEY, "reviews", "written", params] as const,
+	},
+} as const;
+
+/**
+ * 찜 등록/해제 = favorites
+ * 모임 삭제 (찜 갯수와 알림 모두 갱신) = all
+ * 모임 참여, 참여취소,확정,취소,게시글 댓글 = notifications.all
+ */
+const HEADER_QUERY_BASE_KEY = ["header"] as const;
+export const headerQueryKeys = {
+	// 찜 개수
+	all: HEADER_QUERY_BASE_KEY,
+	favorites: [...HEADER_QUERY_BASE_KEY, "favorites"] as const,
+	notifications: {
+		all: [...HEADER_QUERY_BASE_KEY, "notifications"] as const,
+		count: [...HEADER_QUERY_BASE_KEY, "notifications", "count"] as const,
+	},
+} as const;

--- a/features/mypage/types.ts
+++ b/features/mypage/types.ts
@@ -134,6 +134,7 @@ export interface DetailCardProps {
 	badges?: DetailCardBadge[];
 	actions?: DetailCardAction[];
 	actionDisplay?: "buttons" | "dropdown";
+	onDropdownOpenChange?: (open: boolean) => void;
 	wishAction?: DetailCardWishAction;
 }
 
@@ -150,6 +151,7 @@ export interface ReviewCardProps {
 	item: ReviewCardItem;
 	handleEdit: () => void;
 	handleDelete: () => void;
+	onDropdownOpenChange?: (open: boolean) => void;
 }
 
 export type ReviewList = ReviewCardItem[];

--- a/features/mypage/types.ts
+++ b/features/mypage/types.ts
@@ -138,7 +138,7 @@ export interface DetailCardProps {
 	wishAction?: DetailCardWishAction;
 }
 
-export type ReviewCardItem = Omit<MeReviewsApiRes, "score" | "createdAt" | "meeting"> & {
+export type ReviewCardItem = Omit<MeReviewsApiRes, "score" | "meeting"> & {
 	score: ReviewScore;
 	meetingType: string;
 	meetingName: string;

--- a/features/mypage/types.ts
+++ b/features/mypage/types.ts
@@ -163,6 +163,10 @@ export interface MeetupItem extends DetailCardItem {
 	isCompleted: boolean;
 }
 export type MeetupList = MeetupItem[];
+export interface MeetupDetailItem extends MeetupItem {
+	role: Role;
+}
+export type MeetupDetailList = MeetupDetailItem[];
 
 export type WritableReviewItem = DetailCardItem;
 export type WritableReviewList = WritableReviewItem[];

--- a/features/mypage/types.ts
+++ b/features/mypage/types.ts
@@ -13,6 +13,9 @@ interface Host {
 	image: string;
 }
 
+export type Role = "participant" | "host";
+
+// 참여한 모임목록 전체 (작성하지 않은 리뷰에 사용)
 export interface MeetingJoinedApiRes {
 	id: number;
 	teamId: string;
@@ -40,7 +43,7 @@ export interface MeetingJoinedApiRes {
 	joinedAt: string;
 	isReviewed: boolean;
 }
-
+// 작성한 리뷰 목록
 export interface MeReviewsApiRes {
 	id: number;
 	score: number;
@@ -56,7 +59,10 @@ export interface MeReviewsApiRes {
 	createdAt: string;
 }
 
-export type MeetingsMyApiRes = Omit<MeetingJoinedApiRes, "joinedAt" | "isReviewed">;
+// 내가 참여한 모임 목록, 내가 만든 모임 목록
+export type MeMeetingApiRes = MeetingJoinedApiRes & {
+	role: Role;
+};
 
 export type MeetingStatus = "CONFIRMED" | "CANCELED";
 
@@ -160,9 +166,3 @@ export type MeetupList = MeetupItem[];
 
 export type WritableReviewItem = DetailCardItem;
 export type WritableReviewList = WritableReviewItem[];
-export interface CreatedItem extends DetailCardItem {
-	isCompleted: boolean;
-	canceledAt: string | null;
-	confirmedAt: string | null;
-}
-export type CreatedList = CreatedItem[];

--- a/features/mypage/types.ts
+++ b/features/mypage/types.ts
@@ -112,7 +112,7 @@ export interface DetailCardItem {
 }
 export interface DetailCardBadge {
 	label: string;
-	variant: "scheduled" | "confirmed" | "pending" | "completed" | "completedAlt";
+	variant: "scheduled" | "confirmed" | "pending" | "completed" | "completedAlt" | "reviewed";
 	showStatusLabel?: boolean;
 }
 
@@ -133,6 +133,7 @@ export interface DetailCardProps {
 	item: DetailCardItem;
 	badges?: DetailCardBadge[];
 	actions?: DetailCardAction[];
+	actionDisplay?: "buttons" | "dropdown";
 	wishAction?: DetailCardWishAction;
 }
 

--- a/features/mypage/utils.ts
+++ b/features/mypage/utils.ts
@@ -1,0 +1,146 @@
+import { DetailCardAction, DetailCardBadge, MeetupDetailItem } from "./types";
+
+export interface HostMeetupActionHandlers {
+	/** 모임 확정 */
+	onConfirmMeetup: () => void;
+	/** 모임 삭제 */
+	onDeleteMeetup: () => void;
+	/** 모임 취소 */
+	onCancelMeetup: () => void;
+	/** 모임 리뷰 작성 */
+
+	onWriteReview: () => void;
+}
+
+export interface ParticipantMeetupActionHandlers {
+	/** 모임 예약 취소 */
+	onCancelReservation: () => void;
+	onWriteReview: () => void;
+}
+
+export type MeetupActionHandlers = HostMeetupActionHandlers & ParticipantMeetupActionHandlers;
+
+export type HostAlertActionType = "confirm" | "delete" | "cancelMeetup";
+
+export type AlertActionType = HostAlertActionType | "cancelReservation";
+
+// alert 메세지
+export const ALERT_MESSAGE = {
+	confirm: "모임을 확정하시겠습니까?",
+	delete: "모임을 삭제하시겠습니까?",
+	cancelMeetup: "모임을 취소하시겠습니까?",
+	cancelReservation: "모임 예약을 취소하시겠습니까?",
+} satisfies Record<AlertActionType, string>;
+
+export function confirmMeetupAction(handlers: HostMeetupActionHandlers): DetailCardAction {
+	return {
+		label: "모임 확정하기",
+		handleCardButtonClick: handlers.onConfirmMeetup,
+	};
+}
+
+export function cancelMeetupAction(handlers: HostMeetupActionHandlers): DetailCardAction {
+	return {
+		label: "모임 취소하기",
+		handleCardButtonClick: handlers.onCancelMeetup,
+	};
+}
+
+export function deleteMeetupAction(handlers: HostMeetupActionHandlers): DetailCardAction {
+	return {
+		label: "모임 삭제하기",
+		handleCardButtonClick: handlers.onDeleteMeetup,
+		isDestructive: true,
+	};
+}
+
+export function cancelReservationAction(
+	handlers: ParticipantMeetupActionHandlers,
+): DetailCardAction {
+	return {
+		label: "예약 취소하기",
+		variant: "purpleBorder",
+		handleCardButtonClick: handlers.onCancelReservation,
+	};
+}
+
+export function writeReviewAction(
+	handlers: HostMeetupActionHandlers | ParticipantMeetupActionHandlers,
+): DetailCardAction {
+	return {
+		label: "리뷰 작성하기",
+		variant: "purple",
+		handleCardButtonClick: handlers.onWriteReview,
+	};
+}
+// 주최자 액션버튼
+export function getHostMeetupActions(
+	item: MeetupDetailItem,
+	handlers: HostMeetupActionHandlers,
+): DetailCardAction[] {
+	if (item.canceledAt) return [deleteMeetupAction(handlers)];
+
+	if (item.isCompleted) {
+		if (item.isReviewed) return [deleteMeetupAction(handlers)];
+
+		return [writeReviewAction(handlers), deleteMeetupAction(handlers)];
+	}
+
+	if (item.confirmedAt) {
+		return [cancelMeetupAction(handlers), deleteMeetupAction(handlers)];
+	}
+
+	return [
+		confirmMeetupAction(handlers),
+		cancelMeetupAction(handlers),
+		deleteMeetupAction(handlers),
+	];
+}
+// 참여자 액션버튼
+export function getParticipantMeetupActions(
+	item: MeetupDetailItem,
+	handlers: ParticipantMeetupActionHandlers,
+): DetailCardAction[] {
+	if (item.canceledAt) return [];
+
+	if (item.isCompleted) {
+		if (item.isReviewed) return [];
+
+		return [writeReviewAction(handlers)];
+	}
+
+	return [cancelReservationAction(handlers)];
+}
+
+// 모임 상태별 액션
+export function meetupActions(
+	item: MeetupDetailItem,
+	handlers: MeetupActionHandlers,
+): DetailCardAction[] {
+	return item.role === "host"
+		? getHostMeetupActions(item, handlers)
+		: getParticipantMeetupActions(item, handlers);
+}
+
+// 모임 배지 상태
+export function meetupBadges(item: MeetupDetailItem): DetailCardBadge[] {
+	if (item.canceledAt) {
+		return [{ label: "개설 취소", variant: "completedAlt" }];
+	}
+	if (item.isCompleted) {
+		if (item.isReviewed) return [{ label: "리뷰 작성완료", variant: "reviewed" }];
+		return [{ label: "이용 완료", variant: "completed" }];
+	}
+
+	if (item.confirmedAt) {
+		return [
+			{ label: "이용 예정", variant: "scheduled" },
+			{ label: "개설확정", variant: "confirmed", showStatusLabel: true },
+		];
+	}
+
+	return [
+		{ label: "이용 예정", variant: "scheduled" },
+		{ label: "개설 대기", variant: "pending" },
+	];
+}

--- a/hooks/useMeetingFavorite.ts
+++ b/hooks/useMeetingFavorite.ts
@@ -1,10 +1,12 @@
 "use client";
 
-import { CreatedList, CursorPageResponse, MeetupList } from "@/features/mypage/types";
+import { CursorPageResponse, MeetupList } from "@/features/mypage/types";
 import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
 import { headerQueryKeys } from "@/features/header/queries";
 import { deleteMeetingsFavorites, postMeetingsFavorites } from "@/features/mypage/apis";
 import { meetupDetailQueryKeys } from "@/features/meetupDetail/queries";
+import { meetupQueryKeys } from "@/features/meetup/queries";
+import { mypageQueryKeys } from "@/features/mypage/queries";
 
 /**
  * 찜 추가 시 낙관적 업데이트 및 롤백 하는 훅
@@ -14,10 +16,7 @@ import { meetupDetailQueryKeys } from "@/features/meetupDetail/queries";
  * handleWishToggle(item.id, item.isFavorited)
  */
 
-const favoriteQueryPrefixes = [
-	["mypage", "meetups"], // 나의 모임, 작성 가능한 리뷰
-	["mypage", "created"], // 만든 모임
-];
+const favoriteQueryPrefixes = [mypageQueryKeys.meetup.all];
 
 export default function useMeetingFavorite() {
 	const queryClient = useQueryClient();
@@ -41,7 +40,7 @@ export default function useMeetingFavorite() {
 
 			// 캐시 낙관적 업데이트 (api 응답 전 캐시수정)
 			favoriteQueryPrefixes.forEach((queryKey) => {
-				queryClient.setQueriesData<InfiniteData<CursorPageResponse<MeetupList | CreatedList>>>(
+				queryClient.setQueriesData<InfiniteData<CursorPageResponse<MeetupList>>>(
 					{ queryKey },
 					(oldData) => {
 						if (!oldData) return oldData;
@@ -63,7 +62,7 @@ export default function useMeetingFavorite() {
 
 		onSuccess: (_data, variables) => {
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.favorites });
-			queryClient.invalidateQueries({ queryKey: ["meetup", "list"] });
+			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 			queryClient.invalidateQueries({
 				queryKey: meetupDetailQueryKeys.meeting(variables.meetingId),
 			});

--- a/hooks/useMeetingFavorite.ts
+++ b/hooks/useMeetingFavorite.ts
@@ -66,6 +66,7 @@ export default function useMeetingFavorite() {
 			queryClient.invalidateQueries({
 				queryKey: meetupDetailQueryKeys.meeting(variables.meetingId),
 			});
+			queryClient.invalidateQueries({ queryKey: ["favorites"] });
 		},
 		// 실패시 롤백
 		onError: (_error, _variables, context) => {

--- a/utils/api.test.ts
+++ b/utils/api.test.ts
@@ -1,11 +1,15 @@
-import { parseJsonSafely, throwApiError } from "./api";
+import { ApiError, getUserErrorMessage, parseJsonSafely, throwApiError } from "./api";
 
 interface createMockResponseType {
 	ok?: boolean;
 	status?: number;
 	json: () => Promise<unknown>;
 }
-function createMockResponse({ ok = true, status = 200, json }: createMockResponseType): Response {
+function createMockResponse({
+	ok = true,
+	status = 200,
+	json = jest.fn(),
+}: createMockResponseType): Response {
 	return { ok, status, json } as Response;
 }
 describe("utils/api", () => {
@@ -42,7 +46,7 @@ describe("utils/api", () => {
 			});
 		});
 		describe("응답에 실패했을 때", () => {
-			test("응답 바디의 message로 에러를 throw한다", async () => {
+			test("응답 바디에message가 있으면 ApiError를 던진다", async () => {
 				const res = createMockResponse({
 					ok: false,
 					status: 400,
@@ -52,9 +56,21 @@ describe("utils/api", () => {
 					}),
 				});
 
-				await expect(throwApiError(res, "기본 에러 메시지")).rejects.toThrow("잘못된 요청입니다");
+				try {
+					await throwApiError(res, "기본 에러 메시지");
+				} catch (error) {
+					expect(error).toBeInstanceOf(ApiError); // 에러 종류 검증
+					expect((error as ApiError).message).toBe("잘못된 요청입니다");
+					expect(error).toMatchObject({
+						// 에러 내용 검증
+						status: 400,
+						code: "BAD_REQUEST",
+						fallbackMessage: "기본 에러 메시지",
+					});
+				}
 			});
-			test("응답 바디에 message가 없으면 fallbackMessage로 throw한다", async () => {
+
+			test("응답 바디에 message가 없으면 fallbackMessage로 ApiError를 던진다", async () => {
 				const res = createMockResponse({
 					ok: false,
 					status: 400,
@@ -63,18 +79,68 @@ describe("utils/api", () => {
 					}),
 				});
 
-				await expect(throwApiError(res, "기본 에러 메시지")).rejects.toThrow("기본 에러 메시지");
+				try {
+					await throwApiError(res, "기본 에러 메시지");
+				} catch (error) {
+					expect(error).toBeInstanceOf(ApiError);
+					expect(error).toMatchObject({
+						message: "기본 에러 메시지",
+						status: 400,
+						code: "BAD_REQUEST",
+						fallbackMessage: "기본 에러 메시지",
+					});
+				}
 			});
-			test("JSON 파싱에 실패하면 fallbackMessage로 throw한다", async () => {
+
+			test("JSON 파싱에 실패하면 fallbackMessage로 ApiError를 던진다", async () => {
 				const res = createMockResponse({
 					ok: false,
 					status: 500,
 					json: jest.fn().mockRejectedValue(new Error("오류가 발생했습니다")),
 				});
-				await expect(throwApiError(res, "서버 오류가 발생했습니다.")).rejects.toThrow(
-					"서버 오류가 발생했습니다.",
-				);
+
+				try {
+					await throwApiError(res, "서버 오류가 발생했습니다.");
+				} catch (error) {
+					expect(error).toBeInstanceOf(ApiError);
+					expect(error).toMatchObject({
+						message: "서버 오류가 발생했습니다.",
+						status: 500,
+						code: undefined,
+						fallbackMessage: "서버 오류가 발생했습니다.",
+					});
+				}
 			});
 		});
 	});
+
+	describe("getUserErrorMessage()", () => {
+		test("ApiError면 message를 반환한다", () => {
+			const error = new ApiError({
+				message: "백엔드 에러 메시지",
+				status: 400,
+				code: "BAD_REQUEST",
+				fallbackMessage: "기본 에러 메시지",
+			});
+
+			const result = getUserErrorMessage(error, "기본 에러 메시지");
+
+			expect(result).toBe("백엔드 에러 메시지");
+		});
+
+		test("일반 Error면 message를 반환한다", () => {
+			const error = new Error("일반 에러 메시지");
+
+			const result = getUserErrorMessage(error, "기본 에러 메시지");
+
+			expect(result).toBe("일반 에러 메시지");
+		});
+
+		test("Error가 아니면 fallback을 반환한다", () => {
+			const result = getUserErrorMessage("unknown error", "기본 에러 메시지");
+
+			expect(result).toBe("기본 에러 메시지");
+		});
+	});
 });
+// - getUserErrorMessage는 리액트 쿼리에서 toast에 노출할 에러메세지를 위한 유틸함수 추가

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,6 +1,56 @@
-interface ErrorResponse {
+interface ApiErrorParams {
+	message: string;
+	status: number;
 	code?: string;
-	message?: string;
+	fallbackMessage?: string;
+}
+
+/**
+ * API 응답이 실패한 경우 에러 바디의 message를 우선 읽어 throw합니다
+ *
+ * JSON 파싱이 불가능하거나 message가 없는 응답이면 fallbackMessage를 사용합니다
+ *
+ * @param response fetch response 객체
+ * @param fallbackMessage 응답 바디를 읽을 수 없을 때 사용할 기본 에러 메시지
+ * @throws {ApiError} API 실패 응답의 메시지, 상태코드, 에러코드를 담은 에러
+ *
+ * @example
+ * const res = await clientFetch("/users/me", {
+ *   method: "PATCH",
+ *   body: JSON.stringify(payload),
+ * });
+ *
+ * await throwApiError(res, "프로필 수정에 실패했습니다.");
+ * return res.json();
+ */
+
+// 기본 Error를 확장한 커스텀 에러 클래스
+export class ApiError extends Error {
+	status: number; // HTTP 상태코드
+	code?: string; // 백엔드가 내려주는 에러 코드
+	fallbackMessage?: string; // 폴백용 기본메세지
+
+	constructor({ message, status, code, fallbackMessage }: ApiErrorParams) {
+		super(message); // Error 호출
+		this.name = "ApiError"; // 디버깅 용이하도록 이름 명시
+		this.status = status;
+		this.code = code;
+		this.fallbackMessage = fallbackMessage;
+	}
+}
+
+export async function throwApiError(response: Response, fallbackMessage: string): Promise<void> {
+	if (response.ok) return;
+
+	// 응답 실패시 null
+	const data = await response.json().catch(() => null);
+
+	throw new ApiError({
+		message: data?.message ?? fallbackMessage,
+		status: response.status,
+		code: data?.code,
+		fallbackMessage,
+	});
 }
 
 // 백엔드 응답이 비어 있거나 JSON이 아닐 수 있어 안전하게 파싱
@@ -12,30 +62,9 @@ export async function parseJsonSafely(response: Response) {
 	}
 }
 
-/**
- * API 응답이 실패한 경우 에러 바디의 message를 우선 읽어 throw합니다
- *
- * JSON 파싱이 불가능하거나 message가 없는 응답이면 fallbackMessage를 사용합니다
- *
- * @param response fetch response 객체
- * @param fallbackMessage 응답 바디를 읽을 수 없을 때 사용할 기본 에러 메시지
- * @throws {Error} API 실패 응답의 메시지 또는 fallbackMessage
- *
- * @example
- * const res = await clientFetch("/users/me", {
- *   method: "PATCH",
- *   body: JSON.stringify(payload),
- * });
- *
- * await throwApiError(res, "프로필 수정에 실패했습니다.");
- * return res.json();
- */
-export async function throwApiError(response: Response, fallbackMessage: string): Promise<void> {
-	if (response.ok) return;
-
-	const error: ErrorResponse = await response.json().catch(() => ({
-		message: fallbackMessage,
-	}));
-
-	throw new Error(error.message ?? fallbackMessage);
+export function getUserErrorMessage(error: unknown, fallback: string) {
+	if (error instanceof Error) {
+		return error.message || fallback;
+	}
+	return fallback;
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

기존 마이페이지의 참여한 모임에서는 취소내역이 나오지 않았고, 개설한 모임에서만 알 수 있어서 정보의 누락이 있었습니다.
또한 참여한 모임에서는 많은 상태를 알 수 있었지만 개설한 모임에서는 한정적인 상태값만 알 수 있었습니다.
사용하던 api 가 아닌 role 이 있는 api로 변경하여 정보의 누락 및 관리할 수 있는 범위는 늘리는 작업을 했습니다.


## 📝 변경 사항 요약 (Summary)

- api 추가 및 변경
- queryKey 구조 변경 및 임시파일 추가
- api 변경에 따른 mapper , test 추가
- 참여모임 / 개설모임 action 및 badge 추가
- 개설모임 조회 정렬기준 변경
- 리뷰 작성일시 노출
- badge 컴포넌트 reviewed 타입 추가
- ActionDropdown 컴포넌트 open 상태를 받을 수 있는 onOpenChange props 추가

## 💁 변경 사항 이유 (Why)

- queryKey는 api 구조가 변경되었기 때문에 기존에 참여모임 + 작성하지 않은 리뷰가 같은 api 를 썼지만, 참여모임 api 가 변경되면서 쿼리키 구조도 전면 변경이 필요했음
- 참여모임/개설모임의 경우 주최자가 양쪽 탭 모두에서 action을 할 수 있도록 버튼 및 뱃지로 상태제공
- 리뷰 작성여부를 제공하기 위해 badge 타입 추가
- 데스크탑에서 드롭다운을 열고 스크롤을 할 시에 해당 드롭다운 위치로 이동되는 이슈가 발생하여 오픈 여부를 알 수 있는 onOpenChange props 를 추가

## ✅ 테스트 계획 (Test Plan)

- mapper.test 로 변경된 필드 테스트 완료했습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #이슈번호
- Related #295 

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ x] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
