### PR TITLE
fix(meetup): 모임 만들기 모달 표시 및 API 버그 수정

### DIFF
--- a/apis/images.ts
+++ b/apis/images.ts
@@ -43,9 +43,14 @@ async function getPresignedUrl(fileName: string, contentType: string, folder: st
 		body: JSON.stringify({ fileName, contentType, folder }),
 	});
 
-	const data = await res.json();
-	if (!res.ok) throw new Error(data.message);
-	return data;
+	if (!res.ok) {
+		const error: ErrorResponse = await res.json().catch(() => ({
+			code: "UNKNOWN_ERROR",
+			message: "업로드 주소 생성 중 알 수 없는 에러가 발생했습니다.",
+		}));
+		throw new Error(error.message);
+	}
+	return res.json();
 }
 
 /** 이미지 업로드 Step2: S3에 이미지 업로드 */
@@ -57,7 +62,13 @@ async function uploadToS3(presignedUrl: string, file: File) {
 		body: file,
 	});
 
-	const data = await res.json();
-	if (!res.ok) throw new Error(data.message);
-	return data;
+	if (!res.ok) {
+		const error: ErrorResponse = await res.json().catch(() => ({
+			code: "UNKNOWN_ERROR",
+			message: "업로드 중 알 수 없는 에러가 발생했습니다.",
+		}));
+		throw new Error(error.message);
+	}
+
+	return res.json();
 }

--- a/apis/meetingTypes.ts
+++ b/apis/meetingTypes.ts
@@ -15,7 +15,13 @@ export async function getMeetingTypes() {
 		cache: "force-cache",
 	});
 
-	if (!res.ok) throw new Error(`모임 카테고리 조회에 실패했습니다. (${res.status})`);
+	if (!res.ok) {
+		const error = await res.json().catch(() => ({
+			code: "UNKNOWN_ERROR",
+			message: "모임 카테고리 조회에 실패했습니다.",
+		}));
+		throw new Error(error.message);
+	}
 	return res.json();
 }
 

--- a/app/(main)/meetup/@create/(.)create/page.tsx
+++ b/app/(main)/meetup/@create/(.)create/page.tsx
@@ -2,8 +2,7 @@
 
 import { usePathname } from "next/navigation";
 import MeetUpCreate from "@/features/meetup/create";
-
-const MEETUP_CREATE_PATH = "/meetup/create";
+import { MEETUP_CREATE_PATH } from "@/constants/navigation";
 
 // Link 또는 router로 /meetup/create 진입 시
 export default function MeetupCreateInterceptPage() {

--- a/app/(main)/meetup/@create/(.)create/page.tsx
+++ b/app/(main)/meetup/@create/(.)create/page.tsx
@@ -1,6 +1,20 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import MeetUpCreate from "@/features/meetup/create";
+
+const MEETUP_CREATE_PATH = "/meetup/create";
 
 // Link 또는 router로 /meetup/create 진입 시
 export default function MeetupCreateInterceptPage() {
+	const pathname = usePathname();
+
+	// 같은 수준의 다른 페이지에서 표시되는 이슈 수정
+	// window.location.href, pathname 또는 params, proxy 등으로 해결
+	// https://github.com/vercel/next.js/pull/92310
+	if (pathname !== MEETUP_CREATE_PATH) {
+		return null;
+	}
+
 	return <MeetUpCreate />;
 }

--- a/app/api/images/upload/route.ts
+++ b/app/api/images/upload/route.ts
@@ -1,35 +1,44 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(request: NextRequest) {
-	const presignedUrl = request.headers.get("x-presigned-url");
-	if (!presignedUrl) {
-		return NextResponse.json({ message: "Missing x-presigned-url header" }, { status: 400 });
-	}
-
-	const contentType = request.headers.get("content-type");
-	if (!contentType) {
-		return NextResponse.json({ message: "Missing content-type header" }, { status: 400 });
-	}
-
-	const body = await request.arrayBuffer();
-	const response = await fetch(presignedUrl, {
-		method: "PUT",
-		headers: { "Content-Type": contentType },
-		body: body,
-	});
-
-	if (!response.ok) {
-		// 서버 에러 응답이 XML 형식이기 때문에 상태 코드로 분기 처리
-		if (response.status >= 500) {
-			return NextResponse.json(
-				{ message: "서버에 일시적인 문제가 발생했습니다." },
-				{ status: response.status },
-			);
+	try {
+		const presignedUrl = request.headers.get("x-presigned-url");
+		if (!presignedUrl) {
+			return NextResponse.json({ message: "Missing x-presigned-url header" }, { status: 400 });
 		}
-		if (response.status >= 400) {
-			return NextResponse.json({ message: "잘못된 요청입니다." }, { status: response.status });
-		}
-	}
 
-	return NextResponse.json({ success: true });
+		const contentType = request.headers.get("content-type");
+		if (!contentType) {
+			return NextResponse.json({ message: "Missing content-type header" }, { status: 400 });
+		}
+
+		const body = await request.arrayBuffer();
+		const response = await fetch(presignedUrl, {
+			method: "PUT",
+			headers: { "Content-Type": contentType },
+			body: body,
+		});
+
+		if (!response.ok) {
+			// 서버 에러 응답이 XML 형식이기 때문에 상태 코드로 분기 처리
+			if (response.status >= 500) {
+				return NextResponse.json(
+					{ message: "서버에 일시적인 문제가 발생했습니다." },
+					{ status: response.status },
+				);
+			}
+			if (response.status === 413) {
+				return NextResponse.json(
+					{ message: "파일 크기가 너무 큽니다." },
+					{ status: response.status },
+				);
+			}
+			if (response.status >= 400) {
+				return NextResponse.json({ message: "잘못된 요청입니다." }, { status: response.status });
+			}
+		}
+		return NextResponse.json({ success: true });
+	} catch {
+		return NextResponse.json({ message: "서버 오류가 발생했습니다." }, { status: 500 });
+	}
 }

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -18,3 +18,7 @@ export const GNB_MENU_ITEMS = [
 ];
 
 export const ACCOUNT_MENU_ITEM = { href: "/mypage", label: "마이페이지", key: "mypage" };
+
+export const MEETUP_LIST_PATH = "/meetup/list";
+export const MEETUP_CREATE_PATH = "/meetup/create";
+export const MEETUP_DETAIL_PATH = (meetupId: number) => `/meetup/${meetupId}`;

--- a/features/meetup/create/components/CreateOpenButton/index.tsx
+++ b/features/meetup/create/components/CreateOpenButton/index.tsx
@@ -6,6 +6,7 @@ import CreateButton from "@/components/ui/Buttons/CreateButton";
 import { useUser } from "@/hooks/useUser";
 import { useModalStore } from "@/store/modal.store";
 import { useToast } from "@/providers/toast-provider";
+import { MEETUP_CREATE_PATH } from "@/constants/navigation";
 
 export default function CreateOpenButton({ className }: { className?: string }) {
 	const { user } = useUser();
@@ -21,7 +22,7 @@ export default function CreateOpenButton({ className }: { className?: string }) 
 			onClick={() => {
 				if (user) {
 					// 모임 목록 페이지 데이터 변경 이슈 해결을 위한 querystring 추가
-					const url = `/meetup/create${queries ? `?${queries}` : ""}`;
+					const url = `${MEETUP_CREATE_PATH}${queries ? `?${queries}` : ""}`;
 					router.push(url, { scroll: false });
 				} else {
 					handleShowToast({ message: "로그인 후 이용해주세요.", status: "error" });

--- a/features/meetup/create/hooks.ts
+++ b/features/meetup/create/hooks.ts
@@ -1,6 +1,7 @@
 import { useToast } from "@/providers/toast-provider";
 import { useRouter } from "next/navigation";
 import { createSessionStore } from "./utils";
+import { MEETUP_DETAIL_PATH } from "@/constants/navigation";
 
 interface UseCreateMeetupProps {
 	/** 모달 닫기 함수 */
@@ -19,7 +20,7 @@ export function useCreateMeetup({ close }: UseCreateMeetupProps = {}) {
 		createSessionStore.remove();
 		handleShowToast({ message: "모임 생성이 완료되었습니다!", status: "success" });
 		if (close) close();
-		setTimeout(() => router.replace(`/meetup/${id}`), 2000);
+		setTimeout(() => router.replace(MEETUP_DETAIL_PATH(id)), 2000);
 	}
 
 	return { onClose, onSuccess };

--- a/features/meetup/list/components/JoinModal/index.tsx
+++ b/features/meetup/list/components/JoinModal/index.tsx
@@ -9,6 +9,7 @@ import { modalSizeStyle } from "@/features/meetup/styles";
 import Button from "@/components/ui/Buttons/Button";
 import { Modal } from "@/components/ui/Modals";
 import { IcCalendarOutline, IcChevronRight, IcDotPoints, IcLocation } from "@/components/ui/icons";
+import { MEETUP_DETAIL_PATH } from "@/constants/navigation";
 
 interface JoinModalProps {
 	selectedData: MeetupItemSelected | null;
@@ -84,7 +85,7 @@ function JoinModalContent({ selectedData, isOpen, onClose }: JoinModalContentPro
 			<div className="mt-2 text-right">
 				<Link
 					className="inline-flex items-center text-sm text-purple-500 md:text-base"
-					href={`/meetup/${selectedData.id}`}>
+					href={MEETUP_DETAIL_PATH(selectedData.id)}>
 					상세 보기
 					<IcChevronRight {...iconProps} />
 				</Link>

--- a/features/meetup/list/components/MeetupCard/index.tsx
+++ b/features/meetup/list/components/MeetupCard/index.tsx
@@ -8,6 +8,7 @@ import { useDeleteMeetupFavorite, usePostMeetupFavorite } from "@/features/meetu
 import { useUser } from "@/hooks/useUser";
 import { useMeetupToggle } from "@/features/meetup/list/hooks";
 import { useToast } from "@/providers/toast-provider";
+import { MEETUP_DETAIL_PATH } from "@/constants/navigation";
 
 interface MeetupCardProps {
 	data: MeetupItem;
@@ -23,7 +24,7 @@ export default function MeetupCard({ data, setSelectedData, openModalFn }: Meetu
 		isJoined: data.isJoined,
 		isCompleted: data.isCompleted,
 	};
-	const href = `/meetup/${data.id}`;
+	const href = MEETUP_DETAIL_PATH(data.id);
 
 	const { user } = useUser();
 	const { handleShowToast } = useToast();


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 만들기 모달이 동일 수준의 다른 페이지에서 표시되는 버그를 수정하였습니다.

## 📝 변경 사항 요약 (Summary)

- Intercepting/Parallel Routes 버그로 모임 상세나 모임 찾기 페이지에서 표시되는 문제를 수정하였습니다.
현재 NextJS에서 해결 중인 이슈입니다.
```
// /app/(main)/meetup/@create/(.)create/page.tsx
const pathname = usePathname();
if (pathname !== MEETUP_CREATE_PATH) {
return null;
}
```
- 이미지 업로드 api에서 누락된 catch 문을 추가하였습니다.
  - 참고: 이미지 업로드 시 용량 초과 응답이 간헐적으로 발생합니다.
  - [413 Content Too Large - HTTP - MDN Web Docs](https://developer.mozilla.org/ko/docs/Web/HTTP/Reference/Status/413)
- 모임 찾기, 모임 만들기에서 사용되던 페이지 경로 값을 /constants 로 이동하였습니다.

## 💁 변경 사항 이유 (Why)

- 모임 생성 이후, 같은 수준의 /meetup/... 페이지에서 모달이 다시 표시됨

## ✅ 테스트 계획 (Test Plan)

- 빌드 후 실행하여 수동으로 테스트하였습니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #310 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.