### PR TITLE
refactor(meetupDetail): 모임 상세 페이지 레이아웃 간격 & 찜 버튼 UI 수정

### DIFF
--- a/app/(main)/meetup/[meetupId]/layout.tsx
+++ b/app/(main)/meetup/[meetupId]/layout.tsx
@@ -2,7 +2,7 @@ import Container from "@/components/layout/Container";
 
 export default function MeetupDetailLayout({ children }: { children: React.ReactNode }) {
 	return (
-		<Container className="flex flex-col items-center gap-10 py-10 md:py-16 lg:py-20">
+		<Container className="flex flex-col items-center gap-10 py-10 md:gap-16 md:py-16 lg:gap-20 lg:py-20">
 			{children}
 		</Container>
 	);

--- a/components/ui/Inputs/InputField/index.test.tsx
+++ b/components/ui/Inputs/InputField/index.test.tsx
@@ -1,6 +1,5 @@
 import InputField from ".";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 
 describe("InputField 테스트", () => {
 	describe("렌더링 검사", () => {

--- a/features/meetupDetail/components/CommentCards/index.tsx
+++ b/features/meetupDetail/components/CommentCards/index.tsx
@@ -133,7 +133,7 @@ export default function CommentCards({
 			</div>
 
 			<div className="flex h-fit w-full flex-col items-center gap-8 md:gap-10">
-				<div className="flex h-fit w-full flex-col items-center gap-2.5 overflow-hidden rounded-3xl bg-white px-5 pb-2 md:rounded-4xl md:px-12 md:py-6">
+				<div className="flex h-fit w-full flex-col items-center gap-2.5 overflow-hidden rounded-[20px] bg-white px-5 pb-2 md:px-12 md:py-6 lg:rounded-4xl">
 					{hasComments ? (
 						<div className="flex h-fit w-full flex-col">
 							{comments.map((comment) => (

--- a/features/meetupDetail/components/InformationContainer/index.tsx
+++ b/features/meetupDetail/components/InformationContainer/index.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/features/meetupDetail/mutations";
 import { useToast } from "@/providers/toast-provider";
 import { useModalStore } from "@/store/modal.store";
-import SendButton from "@/components/ui/Buttons/SendButton";
 import { cn } from "@/utils/cn";
 import CancelJoinModal from "@/features/meetupDetail/components/InformationContainer/CancelJoinModal";
 import { useUser } from "@/hooks/useUser";
@@ -171,20 +170,16 @@ export default function InformationContainer({
 				</div>
 
 				<div className="flex w-full items-center gap-4">
-					{isRegClosed ? (
-						<SendButton sizes="small" className="pointer-events-none lg:size-15" />
-					) : (
-						<UtilityButton
-							sizes="small"
-							className={cn(
-								"transition-colors lg:size-15",
-								isFavorited ? "border-purple-500" : "hover:border-purple-500",
-							)}
-							pressed={isFavorited}
-							isPending={isFavoritePending}
-							onClick={handleFavoriteConfirm}
-						/>
-					)}
+					<UtilityButton
+						sizes="small"
+						className={cn(
+							"transition-colors lg:size-15",
+							isFavorited ? "border-purple-500" : "hover:border-purple-500",
+						)}
+						pressed={isFavorited}
+						isPending={isFavoritePending}
+						onClick={handleFavoriteConfirm}
+					/>
 					<Button
 						sizes="small"
 						colors={isJoined ? "purpleBorder" : "purple"}

--- a/features/meetupDetail/containers/meetupContainer/MeetupDescSection/index.tsx
+++ b/features/meetupDetail/containers/meetupContainer/MeetupDescSection/index.tsx
@@ -11,11 +11,11 @@ export default function MeetupDescSection({ meetupId }: { meetupId: number }) {
 			initial="hidden"
 			whileInView="visible"
 			viewport={{ once: true, amount: 0.1 }}
-			className="mt-10 flex h-fit w-full flex-col gap-3 md:gap-4 lg:gap-5">
+			className="flex h-fit w-full flex-col gap-3 md:gap-4 lg:gap-5">
 			<span className="pl-1.5 text-base font-semibold md:text-xl lg:pl-2.5 lg:text-2xl">
 				모임 설명
 			</span>
-			<div className="w-full overflow-hidden rounded-3xl bg-white px-5 py-4 md:rounded-4xl md:px-12 md:py-6">
+			<div className="w-full overflow-hidden rounded-[20px] bg-white px-5 py-4 md:px-12 md:py-6 lg:rounded-4xl">
 				<span className="text-sm font-normal whitespace-pre-line text-gray-700 md:text-lg">
 					{meeting.description}
 				</span>

--- a/features/meetupDetail/containers/meetupContainer/MeetupIntroSection/index.tsx
+++ b/features/meetupDetail/containers/meetupContainer/MeetupIntroSection/index.tsx
@@ -21,7 +21,7 @@ export default function MeetupIntroSection({ meetupId }: { meetupId: number }) {
 				initial="hidden"
 				whileInView="visible"
 				viewport={{ once: true, amount: 0.1 }}
-				className="relative aspect-343/241 w-full overflow-hidden rounded-2xl md:aspect-auto md:w-1/2 md:self-stretch lg:rounded-4xl">
+				className="relative aspect-343/241 w-full overflow-hidden rounded-[20px] md:aspect-auto md:w-1/2 md:self-stretch lg:rounded-4xl">
 				<Image alt={meeting.name} src={meeting.image} fill className="object-cover" priority />
 			</motion.div>
 			<motion.div

--- a/features/meetupDetail/containers/meetupContainer/MeetupMapSection/index.tsx
+++ b/features/meetupDetail/containers/meetupContainer/MeetupMapSection/index.tsx
@@ -12,7 +12,7 @@ export default function MeetupMapSection({ meetupId }: { meetupId: number }) {
 			initial="hidden"
 			whileInView="visible"
 			viewport={{ once: true, amount: 0.1 }}
-			className="mt-10 flex h-fit w-full flex-col gap-3 md:mt-16 md:gap-4 lg:mt-20 lg:gap-5">
+			className="flex h-fit w-full flex-col gap-3 md:gap-4 lg:gap-5">
 			<span className="pl-1.5 text-base font-semibold md:text-xl lg:pl-2.5 lg:text-2xl">
 				모임 장소
 			</span>

--- a/features/meetupDetail/containers/meetupContainer/MeetupRelatedSection/index.tsx
+++ b/features/meetupDetail/containers/meetupContainer/MeetupRelatedSection/index.tsx
@@ -19,12 +19,12 @@ export default function MeetupRelatedSection({ meetupId }: { meetupId: number })
 			initial="hidden"
 			whileInView="visible"
 			viewport={{ once: true, amount: 0.1 }}
-			className="mt-17 flex h-fit w-full flex-col gap-3 md:mt-18 md:gap-4 lg:mt-22">
+			className="flex h-fit w-full flex-col gap-3 md:gap-4">
 			<div className="pl-1.5 lg:pl-2.5">
 				<h3 className="text-base font-semibold md:text-xl lg:text-2xl">이런 모임은 어떠세요?</h3>
 			</div>
 			{relatedMeetings.length === 0 ? (
-				<Empty section className="w-full">
+				<Empty section className="w-full rounded-[20px] lg:rounded-4xl">
 					추천 모임이 없어요.
 				</Empty>
 			) : (

--- a/features/meetupDetail/containers/meetupContainer/MeetupReviewSection/index.tsx
+++ b/features/meetupDetail/containers/meetupContainer/MeetupReviewSection/index.tsx
@@ -28,7 +28,7 @@ export default function MeetupReviewSection({ meetupId }: { meetupId: number }) 
 			initial="hidden"
 			whileInView="visible"
 			viewport={{ once: true, amount: 0.1 }}
-			className="mt-10 w-full md:mt-16 lg:mt-20">
+			className="w-full">
 			<CommentCards
 				meetingId={meetupId}
 				comments={comments}

--- a/features/meetupDetail/edit/components/EditModal/index.tsx
+++ b/features/meetupDetail/edit/components/EditModal/index.tsx
@@ -113,7 +113,10 @@ function EditForm({ onClose, isOpen, onSubmit, isPending, participantCount }: Ed
 			}>
 			{/* 탭 */}
 			<div className="mb-4 [&_li]:sm:grow">
-				<PageTabs defaultId={TAB_IDS.BASIC} onChange={({ id }) => setActiveTab(id as TabId)}>
+				<PageTabs
+					key={activeTab}
+					defaultId={activeTab}
+					onChange={({ id }) => setActiveTab(id as TabId)}>
 					<PageTabs.Item id={TAB_IDS.BASIC}>기본 정보</PageTabs.Item>
 					<PageTabs.Item id={TAB_IDS.SCHEDULE}>일정 및 인원</PageTabs.Item>
 				</PageTabs>

--- a/features/meetupDetail/edit/components/EditModal/index.tsx
+++ b/features/meetupDetail/edit/components/EditModal/index.tsx
@@ -97,7 +97,7 @@ function EditForm({ onClose, isOpen, onSubmit, isPending, participantCount }: Ed
 
 	return (
 		<Modal
-			className="w-full p-14 md:min-h-4/5 md:w-136 md:p-12"
+			className="max-h-4/5 w-full p-6 md:min-h-4/5 md:w-136 md:p-8"
 			isOpen={isOpen}
 			onClose={onClose}
 			title="모임 수정하기"
@@ -112,7 +112,7 @@ function EditForm({ onClose, isOpen, onSubmit, isPending, participantCount }: Ed
 				</div>
 			}>
 			{/* 탭 */}
-			<div className="mb-8 [&_li]:sm:grow">
+			<div className="mb-4 [&_li]:sm:grow">
 				<PageTabs defaultId={TAB_IDS.BASIC} onChange={({ id }) => setActiveTab(id as TabId)}>
 					<PageTabs.Item id={TAB_IDS.BASIC}>기본 정보</PageTabs.Item>
 					<PageTabs.Item id={TAB_IDS.SCHEDULE}>일정 및 인원</PageTabs.Item>


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 상세 페이지 UI 간격 및 스타일 규칙을 전반적으로 정리하고, 
액션 버튼 노출 정책을 일관되게 수정했습니다.

## 📄 설계 문서 (Design Document)

## 📝 변경 사항 요약 (Summary)

- `layout.tsx`의 섹션 간 간격을 반응형 `gap` 기준으로 통일
  - `md:gap-16, lg:gap-20` 적용

- 각 섹션에서 개별적으로 사용하던 `mt` 제거
- radius 스타일 기준 통일
- `SendButton` 제거
- 마감 여부 관계 없이, 찜 버튼이 항상 표시되도록 수정

## 💁 변경 사항 이유 (Why)

- 페이지 전반의 시각적 일관성을 높이기 위함
- 불필요한 SendButton 제거로 UI 복잡도를 줄임

## ✅ 테스트 계획 (Test Plan)

- 개발 / 빌드 환경에서 정상적으로 적용되었는지 테스트

## 🔗 관련 이슈 (Related Issues)

- Closed #314 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
