### PR TITLE
fix(favorites,reviews): 필터링 시 상단 이동 기능 개선

### DIFF
--- a/app/(main)/favorites/page.tsx
+++ b/app/(main)/favorites/page.tsx
@@ -6,6 +6,7 @@ import { prefetchFavorites } from "@/features/favorites/queries/prefetchQueries"
 import { FavoritesListRequest } from "@/features/favorites/types";
 import FavoritesSection from "@/features/favorites/components/FavoritesSection";
 import ListControls from "@/features/favorites/components/ListControls";
+import { FavoritesListScrollProvider } from "@/features/favorites/components/providers/FavoritesListScrollProvider";
 
 type Props = {
 	searchParams: Promise<FavoritesListRequest>;
@@ -29,8 +30,8 @@ export default async function FavoritesPage({ searchParams }: Props) {
 	await prefetchFavorites(queryClient, normalizedParams);
 
 	return (
-		<>
-			<header className="mt-8.5 mb-8 md:mt-10 md:mb-14 lg:mt-[3.188rem]">
+		<FavoritesListScrollProvider>
+			<header className="mb-8 pt-8.5 md:mb-14 md:pt-10 lg:pt-[3.188rem]">
 				<PageIntro />
 			</header>
 
@@ -41,6 +42,6 @@ export default async function FavoritesPage({ searchParams }: Props) {
 					<FavoritesSection />
 				</HydrationBoundary>
 			</QueryErrorBoundary>
-		</>
+		</FavoritesListScrollProvider>
 	);
 }

--- a/app/(main)/reviews/page.tsx
+++ b/app/(main)/reviews/page.tsx
@@ -13,6 +13,7 @@ import RatingSummarySkeleton from "@/features/reviews/components/RatingSummary/R
 import ReviewsSection from "@/features/reviews/components/ReviewsCard/ReviewsSectionWrapper/ReviewsSection";
 import QueryErrorBoundary from "@/components/common/QueryErrorBoundary";
 import { getQueryClient } from "@/libs/getQueryClient";
+import { ReviewsListScrollProvider } from "@/features/reviews/components/providers/ReviewsListScrollProvider";
 
 type Props = {
 	searchParams: Promise<ReviewsListRequest>;
@@ -40,8 +41,8 @@ export default async function ReviewsPage({ searchParams }: Props) {
 	await prefetchReviews(queryClient, normalizedParams);
 
 	return (
-		<>
-			<header className="mt-8.5 mb-8 md:mt-10 md:mb-14 lg:mt-[3.188rem]">
+		<ReviewsListScrollProvider>
+			<header className="mb-8 pt-8.5 md:mb-14 md:pt-10 lg:pt-[3.188rem]">
 				<PageIntro />
 			</header>
 
@@ -60,6 +61,6 @@ export default async function ReviewsPage({ searchParams }: Props) {
 					<ReviewsSection />
 				</HydrationBoundary>
 			</QueryErrorBoundary>
-		</>
+		</ReviewsListScrollProvider>
 	);
 }

--- a/features/favorites/components/ListControls/index.tsx
+++ b/features/favorites/components/ListControls/index.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useRef } from "react";
-import useScrollOnNextQueryChange from "@/hooks/useScrollOnNextQueryChange";
 import useScrollFloatingVisibility from "@/hooks/useScrollFloatingVisibility";
 import { cn } from "@/utils/cn";
 import CategoryTabs from "./CategoryTabs";
 import ListFilters from "./ListFilters";
+import { useFavoritesListScroll } from "../providers/FavoritesListScrollProvider";
 
 const MOBILE_STICKY_OFFSET = 48;
 
@@ -33,7 +33,7 @@ function ListControlsContent({ headingId, className, onWillChange }: ListControl
 }
 
 export default function ListControls() {
-	const { scrollAnchorRef, markWillChange } = useScrollOnNextQueryChange<HTMLDivElement>();
+	const { markWillChange } = useFavoritesListScroll();
 	const triggerRef = useRef<HTMLDivElement>(null);
 	const { isVisible, hasPassedThreshold } = useScrollFloatingVisibility({
 		offset: MOBILE_STICKY_OFFSET,
@@ -43,8 +43,6 @@ export default function ListControls() {
 
 	return (
 		<>
-			<div ref={scrollAnchorRef} aria-hidden="true" className="scroll-mt-12 md:scroll-mt-22" />
-
 			<div ref={triggerRef} className="scroll-mt-12 md:sticky md:top-22 md:z-9 md:scroll-mt-22">
 				<div className="md:relative md:left-1/2 md:w-screen md:max-w-[1300px] md:-translate-x-1/2 md:bg-gray-50 md:py-3 md:pl-6 lg:pl-0">
 					<ListControlsContent headingId="favorites-filter-heading" onWillChange={markWillChange} />

--- a/features/favorites/components/providers/FavoritesListScrollProvider.tsx
+++ b/features/favorites/components/providers/FavoritesListScrollProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import useScrollOnNextQueryChange from "@/hooks/useScrollOnNextQueryChange";
+
+type FavoritesListScrollContextValue = {
+	markWillChange: () => void;
+};
+
+const FavoritesListScrollContext = createContext<FavoritesListScrollContextValue | null>(null);
+
+export function FavoritesListScrollProvider({ children }: { children: ReactNode }) {
+	const { scrollAnchorRef, markWillChange } = useScrollOnNextQueryChange();
+
+	const value = useMemo(() => ({ markWillChange }), [markWillChange]);
+
+	return (
+		<FavoritesListScrollContext.Provider value={value}>
+			<div
+				ref={scrollAnchorRef}
+				className="pointer-events-none shrink-0 scroll-mt-12 md:scroll-mt-22"
+				aria-hidden
+			/>
+			{children}
+		</FavoritesListScrollContext.Provider>
+	);
+}
+
+export function useFavoritesListScroll() {
+	const ctx = useContext(FavoritesListScrollContext);
+	if (!ctx) {
+		throw new Error("useFavoritesListScroll must be used within FavoritesListScrollProvider");
+	}
+	return ctx;
+}

--- a/features/reviews/components/ListControls/index.tsx
+++ b/features/reviews/components/ListControls/index.tsx
@@ -6,6 +6,7 @@ import useScrollFloatingVisibility from "@/hooks/useScrollFloatingVisibility";
 import { cn } from "@/utils/cn";
 import CategoryTabs from "./CategoryTabs";
 import ListFilters from "./ListFilters";
+import { useReviewsListScroll } from "../providers/ReviewsListScrollProvider";
 
 const MOBILE_STICKY_OFFSET = 48;
 
@@ -33,7 +34,7 @@ function ListControlsContent({ headingId, className, onWillChange }: ListControl
 }
 
 export default function ListControls() {
-	const { scrollAnchorRef, markWillChange } = useScrollOnNextQueryChange<HTMLDivElement>();
+	const { markWillChange } = useReviewsListScroll();
 	const triggerRef = useRef<HTMLDivElement>(null);
 	const { isVisible, hasPassedThreshold } = useScrollFloatingVisibility({
 		offset: MOBILE_STICKY_OFFSET,
@@ -43,7 +44,6 @@ export default function ListControls() {
 
 	return (
 		<>
-			<div ref={scrollAnchorRef} aria-hidden="true" className="scroll-mt-12 md:scroll-mt-22" />
 			<div
 				ref={triggerRef}
 				className="scroll-mt-12 md:sticky md:top-22 md:z-9 md:scroll-mt-22 md:bg-gray-50 md:py-3">

--- a/features/reviews/components/ListControls/index.tsx
+++ b/features/reviews/components/ListControls/index.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef } from "react";
-import useScrollOnNextQueryChange from "@/hooks/useScrollOnNextQueryChange";
 import useScrollFloatingVisibility from "@/hooks/useScrollFloatingVisibility";
 import { cn } from "@/utils/cn";
 import CategoryTabs from "./CategoryTabs";

--- a/features/reviews/components/providers/ReviewsListScrollProvider.tsx
+++ b/features/reviews/components/providers/ReviewsListScrollProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import useScrollOnNextQueryChange from "@/hooks/useScrollOnNextQueryChange";
+
+type ReviewsListScrollContextValue = {
+	markWillChange: () => void;
+};
+
+const ReviewsListScrollContext = createContext<ReviewsListScrollContextValue | null>(null);
+
+export function ReviewsListScrollProvider({ children }: { children: ReactNode }) {
+	const { scrollAnchorRef, markWillChange } = useScrollOnNextQueryChange();
+
+	const value = useMemo(() => ({ markWillChange }), [markWillChange]);
+
+	return (
+		<ReviewsListScrollContext.Provider value={value}>
+			<div
+				ref={scrollAnchorRef}
+				className="pointer-events-none shrink-0 scroll-mt-12 md:scroll-mt-22"
+				aria-hidden
+			/>
+			{children}
+		</ReviewsListScrollContext.Provider>
+	);
+}
+
+export function useReviewsListScroll() {
+	const ctx = useContext(ReviewsListScrollContext);
+	if (!ctx) {
+		throw new Error("useReviewsListScroll must be used within ReviewsListScrollProvider");
+	}
+	return ctx;
+}

--- a/hooks/useScrollOnNextQueryChange.ts
+++ b/hooks/useScrollOnNextQueryChange.ts
@@ -7,7 +7,7 @@ interface UseScrollOnNextQueryChangeProps {
 	behavior?: "auto" | "smooth";
 }
 export default function useScrollOnNextQueryChange<T extends HTMLElement = HTMLDivElement>({
-	behavior = "smooth",
+	behavior = "auto",
 }: UseScrollOnNextQueryChangeProps = {}) {
 	const searchParams = useSearchParams();
 	const searchParamsKey = searchParams.toString();


### PR DESCRIPTION
## 🛠️ 설명 (Description)

- 찜한 모임, 모든 리뷰에서 필터 조건 변경 시 스크롤이 이동하는 방식 조정
- 기존에는 부드러운 스크롤과 상대적으로 아래쪽 기준 위치로 이동해 사용자가 변경된 결과를 바로 보기까지 한 템포 느렸습니다. 이번 변경으로는 필터 적용 직후 목록 시작 지점으로 즉시 이동하도록 수정했습니다.

## 📄 설계 문서 (Design Document)

* 별도 설계 문서 없음

## 📝 변경 사항 요약 (Summary)

* 필터 변경 후 스크롤 이동 동작을 `smooth`에서 `auto`로 변경
* 스크롤 이동 기준 위치를 목록 상단 기준으로 조정
* 필터 적용 후 변경된 리스트를 더 빠르게 확인할 수 있도록 UX 개선

## 💁 변경 사항 이유 (Why)

* 필터를 바꾼 직후 결과 리스트를 즉시 확인할 수 있도록 하기 위해
* `smooth` 스크롤이 오히려 반응이 느리게 느껴질 수 있어 즉시 이동 방식으로 개선하기 위해
* 스크롤 도착 지점이 애매하게 남지 않도록 목록 시작 위치를 명확하게 맞추기 위해

## ✅ 테스트 계획 (Test Plan)

* 찜한 모임 목록에서 카테고리/필터 변경 시 목록 상단으로 즉시 이동하는지 확인
* 리뷰 목록에서 카테고리/필터 변경 시 목록 상단으로 즉시 이동하는지 확인
* 필터 변경 후 데이터 갱신과 스크롤 이동이 자연스럽게 이어지는지 수동 테스트

## 🔗 관련 이슈 (Related Issues)

* Resolves #321

## ☑️ 체크리스트 (Checklist)

* [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
* [ ] 테스트 코드가 작성되었고, 통과했습니다.
* [x] 변경 사항에 대한 문서화가 완료되었습니다.
* [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
* [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
