### PR TITLE
fix(connect): 페이지 이동 시 생기는 문제 해결

### DIFF
--- a/features/connect/components/IntroSection/index.tsx
+++ b/features/connect/components/IntroSection/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Suspense } from "react";
+import { useEffect, Suspense } from "react";
 import dynamic from "next/dynamic";
 import CreateButton from "@/components/ui/Buttons/CreateButton";
 import { useUser } from "@/hooks/useUser";
@@ -18,6 +18,10 @@ export default function IntroSection() {
 	const { user } = useUser();
 	const { openLogin } = useModalStore();
 	const { handleShowToast } = useToast();
+
+	useEffect(() => {
+		window.scrollTo({ top: 0, behavior: "instant" });
+	}, []);
 
 	return (
 		<>


### PR DESCRIPTION

## 🛠️ 설명 (Description)

Connect 페이지 진입 시 스크롤 위치 초기화

## 📝 변경 사항 요약 (Summary)

- 타 페이지에서 스크롤 후 Connect 페이지 진입 시 스크롤이 하단에 위치하는 문제 해결

## 💁 변경 사항 이유 (Why)

- 브라우저의 스크롤 복원 동작으로 인해 이전 페이지의 스크롤 위치가 Connect 페이지에 그대로 적용되는 문제가 있었음
- IntroSection 마운트 시 window.scrollTo({ top: 0, behavior: "instant" })로 강제 초기화

## ✅ 테스트 계획 (Test Plan)

- 랜딩, 모임 찾기, 찜한 목록, 모든 리뷰 페이지에서 스크롤 후 Connect 페이지 진입 시 최상단 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #324

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.

