### PR TITLE
fix(connect): Connect 게시판 목록 상태 URL 동기화

### DIFF
--- a/app/(main)/connect/page.tsx
+++ b/app/(main)/connect/page.tsx
@@ -14,27 +14,34 @@ export const metadata: Metadata = {
 	title: "커넥트",
 };
 
+type SortBy = "createdAt" | "likeCount" | "viewCount" | "commentCount";
+const VALID_SORT_BY: SortBy[] = ["createdAt", "likeCount", "viewCount", "commentCount"];
+
 export default async function ConnectPage({
 	searchParams,
 }: {
-	searchParams: Promise<{ page?: string }>;
+	searchParams: Promise<{ page?: string; sortBy?: string; keyword?: string }>;
 }) {
-	const { page: pageParam } = await searchParams;
+	const { page: pageParam, sortBy: sortByParam, keyword: keywordParam } = await searchParams;
 	const page = Number(pageParam ?? 1);
+	const sortBy: SortBy = VALID_SORT_BY.includes(sortByParam as SortBy)
+		? (sortByParam as SortBy)
+		: "createdAt";
+	const keyword = keywordParam ?? "";
+	const LIMIT = 5;
 
 	const queryClient = getQueryClient();
-	const sortBy = "createdAt";
-	const LIMIT = 5;
 
 	await Promise.all([
 		queryClient.prefetchQuery({
-			queryKey: connectQueryKeys.list(page, sortBy, LIMIT, ""),
+			queryKey: connectQueryKeys.list(page, sortBy, LIMIT, keyword),
 			queryFn: async () => {
 				const queryParams = new URLSearchParams({
 					type: "all",
 					sortBy,
 					offset: String((page - 1) * LIMIT),
 					limit: String(LIMIT),
+					...(keyword ? { keyword } : {}),
 				});
 				const res = await serverFetch(`/posts?${queryParams.toString()}`);
 				if (!res.ok) throw new Error("게시글 조회 실패");

--- a/features/connect/containers/PostContainer/index.tsx
+++ b/features/connect/containers/PostContainer/index.tsx
@@ -34,12 +34,17 @@ export default function PostContainer() {
 	const [shouldScroll, setShouldScroll] = useState(false);
 
 	// URL searchParams에서 초기값 읽기
-	const [page, setPage] = useState(Number(searchParams.get("page") ?? 1));
-	const [sortBy, setSortBy] = useState<SortBy>(
-		(searchParams.get("sortBy") as SortBy) ?? "createdAt",
-	);
-	const [keyword, setKeyword] = useState(searchParams.get("keyword") ?? "");
-	const [searchKeyword, setSearchKeyword] = useState(searchParams.get("keyword") ?? "");
+	const page = Number(searchParams.get("page") ?? 1);
+	const sortByParam = searchParams.get("sortBy");
+	const sortBy: SortBy = SORT_OPTIONS.some((opt) => opt.value === sortByParam)
+		? (sortByParam as SortBy)
+		: "createdAt";
+	const searchKeyword = searchParams.get("keyword") ?? "";
+	const [keyword, setKeyword] = useState(searchKeyword);
+
+	useEffect(() => {
+		setKeyword(searchKeyword);
+	}, [searchKeyword]);
 
 	useEffect(() => {
 		if (searchParams.get("deleted") === "true" && !deletedHandled.current) {
@@ -75,22 +80,16 @@ export default function PostContainer() {
 	};
 
 	const handleSearch = () => {
-		setPage(1);
-		setSearchKeyword(keyword);
-		updateURL({ page: 1, sortBy, keyword });
+		updateURL({ page: 1, sortBy, keyword }); // setPage, setSearchKeyword 제거
 	};
 
 	const handleSortChange = (value: string) => {
-		const newSortBy = value as SortBy;
-		setSortBy(newSortBy);
-		setPage(1);
-		updateURL({ page: 1, sortBy: newSortBy, keyword: searchKeyword });
+		updateURL({ page: 1, sortBy: value, keyword: searchKeyword }); // setSortBy 제거
 	};
 
 	const handlePageChange = (newPage: number) => {
-		setPage(newPage);
 		setShouldScroll(true);
-		updateURL({ page: newPage, sortBy, keyword: searchKeyword });
+		updateURL({ page: newPage, sortBy, keyword: searchKeyword }); // setPage 제거
 	};
 
 	const posts = data?.data ?? [];
@@ -111,7 +110,6 @@ export default function PostContainer() {
 					onSearchClick={handleSearch}
 					onClear={() => {
 						setKeyword("");
-						setSearchKeyword("");
 						updateURL({ page: 1, sortBy, keyword: "" });
 					}}
 					placeholder="궁금한 내용을 검색해보세요."

--- a/features/connect/containers/PostContainer/index.tsx
+++ b/features/connect/containers/PostContainer/index.tsx
@@ -23,19 +23,23 @@ const SORT_OPTIONS = [
 
 const LIMIT = 5;
 
+type SortBy = "createdAt" | "likeCount" | "viewCount" | "commentCount";
+
 export default function PostContainer() {
-	const [page, setPage] = useState(1);
-	const [sortBy, setSortBy] = useState<"createdAt" | "likeCount" | "viewCount" | "commentCount">(
-		"createdAt",
-	);
 	const searchParams = useSearchParams();
+	const router = useRouter();
 	const { handleShowToast } = useToast();
 	const deletedHandled = useRef(false);
-	const [keyword, setKeyword] = useState("");
-	const [searchKeyword, setSearchKeyword] = useState("");
-	const router = useRouter();
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const [shouldScroll, setShouldScroll] = useState(false);
+
+	// URL searchParams에서 초기값 읽기
+	const [page, setPage] = useState(Number(searchParams.get("page") ?? 1));
+	const [sortBy, setSortBy] = useState<SortBy>(
+		(searchParams.get("sortBy") as SortBy) ?? "createdAt",
+	);
+	const [keyword, setKeyword] = useState(searchParams.get("keyword") ?? "");
+	const [searchKeyword, setSearchKeyword] = useState(searchParams.get("keyword") ?? "");
 
 	useEffect(() => {
 		if (searchParams.get("deleted") === "true" && !deletedHandled.current) {
@@ -55,9 +59,38 @@ export default function PostContainer() {
 		}
 	}, [isFetching, shouldScroll]);
 
+	// URL 업데이트 헬퍼
+	const updateURL = (params: { page?: number; sortBy?: string; keyword?: string }) => {
+		const current = new URLSearchParams(searchParams.toString());
+		if (params.page !== undefined) current.set("page", String(params.page));
+		if (params.sortBy !== undefined) current.set("sortBy", params.sortBy);
+		if (params.keyword !== undefined) {
+			if (params.keyword) {
+				current.set("keyword", params.keyword);
+			} else {
+				current.delete("keyword");
+			}
+		}
+		router.push(`?${current.toString()}`, { scroll: false });
+	};
+
 	const handleSearch = () => {
 		setPage(1);
 		setSearchKeyword(keyword);
+		updateURL({ page: 1, sortBy, keyword });
+	};
+
+	const handleSortChange = (value: string) => {
+		const newSortBy = value as SortBy;
+		setSortBy(newSortBy);
+		setPage(1);
+		updateURL({ page: 1, sortBy: newSortBy, keyword: searchKeyword });
+	};
+
+	const handlePageChange = (newPage: number) => {
+		setPage(newPage);
+		setShouldScroll(true);
+		updateURL({ page: newPage, sortBy, keyword: searchKeyword });
 	};
 
 	const posts = data?.data ?? [];
@@ -76,14 +109,14 @@ export default function PostContainer() {
 						if (e.key === "Enter") handleSearch();
 					}}
 					onSearchClick={handleSearch}
-					onClear={() => setKeyword("")}
+					onClear={() => {
+						setKeyword("");
+						setSearchKeyword("");
+						updateURL({ page: 1, sortBy, keyword: "" });
+					}}
 					placeholder="궁금한 내용을 검색해보세요."
 				/>
-				<FilterDropdown
-					value={sortBy}
-					items={SORT_OPTIONS}
-					onChange={(value) => setSortBy(value as typeof sortBy)}
-				/>
+				<FilterDropdown value={sortBy} items={SORT_OPTIONS} onChange={handleSortChange} />
 			</div>
 
 			{/* 게시글 목록 */}
@@ -124,10 +157,7 @@ export default function PostContainer() {
 				<Pagination
 					currentPage={page}
 					totalPages={totalPages}
-					handlePageChange={(newPage) => {
-						setPage(newPage);
-						setShouldScroll(true);
-					}}
+					handlePageChange={handlePageChange}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
## 🛠️ 설명 (Description)

게시글 페이지 이동 후 상세페이지 진입 -> 뒤로가기하면 게시글 1페이지로 이동하는 불편함 해결


## 📝 변경 사항 요약 (Summary)

- 페이지, 정렬, 검색 키워드를 URL 쿼리 파라미터로 관리
- 게시글 상세 진입 후 뒤로가기 시 이전 목록 상태 복원

## 💁 변경 사항 이유 (Why)

- 기존에는 상태를 클라이언트 state로만 관리해서 상세 페이지에서 뒤로가기 시 항상 1페이지 최신순으로 초기화되는 문제가 있었음
- URL에 상태를 반영해 뒤로가기/새로고침 시에도 이전 상태 복원 가능

## ✅ 테스트 계획 (Test Plan)

- 3페이지 좋아요순으로 이동 후 게시글 클릭 → 뒤로가기 시 3페이지 좋아요순 복원 확인
- 검색 후 게시글 클릭 → 뒤로가기 시 검색 결과 복원 확인
- 새로고침 시에도 동일한 상태 유지 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #331

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
