### PR TITLE
fix(logout): 로그아웃시 세션스토리지 데이터 삭제

### DIFF
--- a/features/auth/mutations.ts
+++ b/features/auth/mutations.ts
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postLogin, postSignUp, postLogout, postOAuthLogin } from "@/features/auth/apis";
 import { useToast } from "@/providers/toast-provider";
 import { useRouter } from "next/navigation";
-import { createSessionStore } from "@/features/meetup/create/utils";
 
 export function useLogin(onSuccess: () => void) {
 	const queryClient = useQueryClient();
@@ -68,7 +67,7 @@ export function useLogout() {
 		},
 		onSettled: () => {
 			queryClient.clear();
-			createSessionStore.remove();
+			sessionStorage.clear();
 			router.refresh();
 		},
 	});

--- a/features/auth/mutations.ts
+++ b/features/auth/mutations.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postLogin, postSignUp, postLogout, postOAuthLogin } from "@/features/auth/apis";
 import { useToast } from "@/providers/toast-provider";
 import { useRouter } from "next/navigation";
+import { createSessionStore } from "@/features/meetup/create/utils";
 
 export function useLogin(onSuccess: () => void) {
 	const queryClient = useQueryClient();
@@ -67,6 +68,7 @@ export function useLogout() {
 		},
 		onSettled: () => {
 			queryClient.clear();
+			createSessionStore.remove();
 			router.refresh();
 		},
 	});


### PR DESCRIPTION
## 🛠️ 설명 (Description)

  로그아웃 시 모임 만들기 임시 저장 데이터(sessionStorage)를 초기화합니다.

## 📝 변경 사항 요약 (Summary)

 - useLogout의 onSettled에서 createSessionStore.remove() 호출 추가

## 💁 변경 사항 이유 (Why)

 - 로그아웃 후 다른 계정으로 로그인했을 때 이전 계정의 모임 만들기 입력값이 남아있는 문제 방지

## ✅ 테스트 계획 (Test Plan)

- 모임 만들기 모달에서 내용 입력 후 로그아웃 → 다른 계정으로 로그인 → 모임 만들기 모달 재오픈 시 데이터 초기화 확인

## 🔗 관련 이슈 (Related Issues)

- Closed #340 

## ☑️ 체크리스트 (Checklist)

- [ ] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [ ] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
