### PR TITLE
feat(meetup): 모임 만들기 텍스트 유효성 검사 함수 추가, 날짜 필드 토스트 추가

### DIFF
--- a/features/meetup/create/components/StepInfo/index.tsx
+++ b/features/meetup/create/components/StepInfo/index.tsx
@@ -7,6 +7,7 @@ import { useFormData } from "../../providers/FormDataProvider";
 import AddressField from "@/features/meetup/components/AddressField";
 import NameField from "@/features/meetup/components/NameField";
 import FileField from "@/features/meetup/components/FileField";
+import { validateAddressDetail, validateName } from "@/features/meetup/utils";
 
 interface StepInfoProps {
 	/** 단계 숫자 */
@@ -21,9 +22,10 @@ export default function StepInfo({ step, uploadImageFn, getKakaoPlaceFn }: StepI
 	// 유효성 검사 및 데이터 업데이트
 	useEffect(() => {
 		const { latitude, longitude, _addressName, _addressDetail, region } = data;
+		const isNameValid = validateName(data.name);
 		const isCoorValid = latitude && longitude;
-		const isLocationValid = !!(_addressName && _addressDetail && region);
-		const isValid = !!(data.name && data.image && isCoorValid && isLocationValid);
+		const isLocationValid = !!(_addressName && validateAddressDetail(_addressDetail) && region);
+		const isValid = !!(isNameValid && data.image && isCoorValid && isLocationValid);
 		setStepValid(step, isValid);
 	}, [data, setStepValid, step]);
 

--- a/features/meetup/create/components/StepSchedule/index.tsx
+++ b/features/meetup/create/components/StepSchedule/index.tsx
@@ -23,15 +23,13 @@ export default function StepSchedule({ step }: StepScheduleProps) {
 		type: typeof DATE_KEY | typeof TIME_KEY,
 		value: string,
 	) {
-		let next: MeetupCreateFormData | undefined;
-		setData((prev) => {
-			next =
-				key === DATE_TIME_KEY
-					? { ...prev, _dateTime: { ...prev._dateTime, [type]: value } }
-					: { ...prev, _registrationEnd: { ...prev._registrationEnd, [type]: value } };
-			return next;
-		});
-		if (!next) return;
+		const isDateTimeKey = key === DATE_TIME_KEY;
+		const keyName = isDateTimeKey ? "_dateTime" : "_registrationEnd";
+		const next = {
+			...data,
+			[keyName]: { ...data[key], [type]: value },
+		};
+		setData(next);
 
 		const { date: meetDate, time: meetTime } = next._dateTime;
 		const { date: regDate, time: regTime } = next._registrationEnd;
@@ -46,7 +44,7 @@ export default function StepSchedule({ step }: StepScheduleProps) {
 				registrationEnd: next._registrationEnd,
 			});
 
-		if (key === DATE_TIME_KEY) {
+		if (isDateTimeKey) {
 			if (!meetDate || !meetTime) return;
 			if (!validateDateTime(meetDate, meetTime)) {
 				handleShowToast({ message: MESSAGE_SCHEDULE_AFTER_NOW, status: "error" });
@@ -56,8 +54,7 @@ export default function StepSchedule({ step }: StepScheduleProps) {
 				handleShowToast({ message: MESSAGE_SCHEDULE_ORDER, status: "error" });
 				return;
 			}
-		}
-		if (key === REG_END_KEY) {
+		} else {
 			if (!regDate || !regTime) return;
 			if (!validateDateTime(regDate, regTime)) {
 				handleShowToast({ message: MESSAGE_REGISTRATION_END_AFTER_NOW, status: "error" });

--- a/features/meetup/create/components/StepSchedule/index.tsx
+++ b/features/meetup/create/components/StepSchedule/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useFormData, type MeetupCreateFormData } from "../../providers/FormDataProvider";
+import { useFormData } from "../../providers/FormDataProvider";
 import CapacityField from "@/features/meetup/components/CapacityField";
 import DateTimeField from "@/features/meetup/components/DateTimeField";
 import { validateCapacity, validateDateTime, validateDateTimeOrder } from "../../../utils";

--- a/features/meetup/create/components/StepSchedule/index.tsx
+++ b/features/meetup/create/components/StepSchedule/index.tsx
@@ -1,33 +1,72 @@
 "use client";
 
 import { useEffect } from "react";
-import { useFormData } from "../../providers/FormDataProvider";
+import { useFormData, type MeetupCreateFormData } from "../../providers/FormDataProvider";
 import CapacityField from "@/features/meetup/components/CapacityField";
 import DateTimeField from "@/features/meetup/components/DateTimeField";
 import { validateCapacity, validateDateTime, validateDateTimeOrder } from "../../../utils";
 import { validateMaxCapacity } from "@/features/meetupDetail/edit/utils";
 import { MIN_CONFIRMED_COUNT } from "@/features/meetupDetail/components/PersonnelContainer";
+import { useToast } from "@/providers/toast-provider";
 
 interface StepScheduleProps {
 	/** 단계 숫자 */
 	step: number;
 }
+
 export default function StepSchedule({ step }: StepScheduleProps) {
 	const { setStepValid, setData, data } = useFormData();
+	const { handleShowToast } = useToast();
 
 	function handleChangeSchedule(
 		key: typeof DATE_TIME_KEY | typeof REG_END_KEY,
 		type: typeof DATE_KEY | typeof TIME_KEY,
 		value: string,
 	) {
+		let next: MeetupCreateFormData | undefined;
+		setData((prev) => {
+			next =
+				key === DATE_TIME_KEY
+					? { ...prev, _dateTime: { ...prev._dateTime, [type]: value } }
+					: { ...prev, _registrationEnd: { ...prev._registrationEnd, [type]: value } };
+			return next;
+		});
+		if (!next) return;
+
+		const { date: meetDate, time: meetTime } = next._dateTime;
+		const { date: regDate, time: regTime } = next._registrationEnd;
+
+		const badOrder =
+			!!meetDate &&
+			!!meetTime &&
+			!!regDate &&
+			!!regTime &&
+			!validateDateTimeOrder({
+				dateTime: next._dateTime,
+				registrationEnd: next._registrationEnd,
+			});
+
 		if (key === DATE_TIME_KEY) {
-			setData((prev) => ({ ...prev, _dateTime: { ...prev._dateTime, [type]: value } }));
+			if (!meetDate || !meetTime) return;
+			if (!validateDateTime(meetDate, meetTime)) {
+				handleShowToast({ message: MESSAGE_SCHEDULE_AFTER_NOW, status: "error" });
+				return;
+			}
+			if (badOrder) {
+				handleShowToast({ message: MESSAGE_SCHEDULE_ORDER, status: "error" });
+				return;
+			}
 		}
 		if (key === REG_END_KEY) {
-			setData((prev) => ({
-				...prev,
-				_registrationEnd: { ...prev._registrationEnd, [type]: value },
-			}));
+			if (!regDate || !regTime) return;
+			if (!validateDateTime(regDate, regTime)) {
+				handleShowToast({ message: MESSAGE_REGISTRATION_END_AFTER_NOW, status: "error" });
+				return;
+			}
+			if (badOrder) {
+				handleShowToast({ message: MESSAGE_SCHEDULE_ORDER, status: "error" });
+				return;
+			}
 		}
 	}
 
@@ -45,13 +84,14 @@ export default function StepSchedule({ step }: StepScheduleProps) {
 		});
 		const isCapacityValid = validateCapacity(data.capacity);
 		const isMaxCapacityValid = validateMaxCapacity(data.capacity, MIN_CONFIRMED_COUNT);
-		const isValid =
+		setStepValid(
+			step,
 			isDateTimeValid &&
-			isRegEndValid &&
-			isDateTimeOrderValid &&
-			isCapacityValid &&
-			isMaxCapacityValid;
-		setStepValid(step, isValid);
+				isRegEndValid &&
+				isDateTimeOrderValid &&
+				isCapacityValid &&
+				isMaxCapacityValid,
+		);
 	}, [data, setStepValid, step]);
 
 	return (
@@ -78,3 +118,7 @@ const DATE_TIME_KEY = "_dateTime";
 const REG_END_KEY = "_registrationEnd";
 const DATE_KEY = "date";
 const TIME_KEY = "time";
+
+const MESSAGE_SCHEDULE_AFTER_NOW = "모임 일정은 현재 시각 이후여야 합니다.";
+const MESSAGE_REGISTRATION_END_AFTER_NOW = "모집 마감 날짜는 현재 시각 이후여야 합니다.";
+const MESSAGE_SCHEDULE_ORDER = "모임 일정이 모집 마감 날짜보다 이전입니다.";

--- a/features/meetup/utils.ts
+++ b/features/meetup/utils.ts
@@ -9,6 +9,16 @@ export function validateText(value: string) {
 	return !!value.trim();
 }
 
+/** 모임 이름 유효성 검사 */
+export function validateName(value: string) {
+	return validateText(value) && value.length <= MAX_NAME_LENGTH;
+}
+
+/** 주소 상세 유효성 검사 */
+export function validateAddressDetail(value: string) {
+	return validateText(value) && value.length <= MAX_ADDRESS_LENGTH;
+}
+
 /** 모임 일시, 모집 마감 일시 유효성 검사
  * date: YYYY-MM-DD
  * time: HH:mm


### PR DESCRIPTION
## 🛠️ 설명 (Description)

모임 만들기 폼에서 텍스트 길이 관련 유효성 검사 함수를 적용하고, 날짜 필드 토스트를 추가하였습니다.

## 📝 변경 사항 요약 (Summary)

- 텍스트 필드에 대한 길이 유효성 검사 함수를 추가하였습니다.
- 모임일정, 모임마감날짜의 토스트 메시지를 표시하였습니다.
    - 날짜 필드의 onChange 이벤트에서 입력된 모든 날짜 데이터가 유효한지 확인합니다.
    - 날짜가 현재 시각보다 이전인지, 두 날짜의 순서가 유효한지를 판단합니다.
    - 입력된 값에 대한 유효성 검사가 우선 적용됩니다.
<img width="586" height="716" alt="image" src="https://github.com/user-attachments/assets/53ca8b42-8bee-4201-8579-fc79ce56608e" />
<img width="573" height="709" alt="image" src="https://github.com/user-attachments/assets/14809e7a-8932-4deb-97f7-40612d13d207" />

## 💁 변경 사항 이유 (Why)

- 텍스트 길이 제한 관련 maxLength attribute 가 있음에도 불구하고 다음 단계로 진입
- 사용자 입장에서 입력 값이 통과하지 못하는 이유를 알기 어려움

## ✅ 테스트 계획 (Test Plan)

- 추가 테스트 코드 작성 계획입니다.

## 🔗 관련 이슈 (Related Issues)

- Closed #339 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [ ] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [x] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.
