### PR TITLE
test(reviews/favorites): 리뷰·찜 서버 API 테스트 추가

### DIFF
--- a/features/favorites/apis/server.test.ts
+++ b/features/favorites/apis/server.test.ts
@@ -1,0 +1,231 @@
+jest.mock("next/headers", () => ({
+	cookies: jest.fn(),
+}));
+
+import { cookies } from "next/headers";
+import { http, HttpResponse } from "msw";
+import { getFavorites } from "@/features/favorites/apis/server";
+import { server } from "@/mocks/server";
+import { ApiError } from "@/utils/api";
+import type { FavoriteMeeting, FavoritesListResponse } from "../types";
+
+const TEST_API_BASE = "http://localhost/api";
+
+const mockedCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
+
+function createCookieStore(tokens: { accessToken?: string; refreshToken?: string } = {}) {
+	return {
+		get: jest.fn((name: string) => {
+			if (name === "accessToken" && tokens.accessToken) {
+				return { name, value: tokens.accessToken };
+			}
+
+			if (name === "refreshToken" && tokens.refreshToken) {
+				return { name, value: tokens.refreshToken };
+			}
+
+			return undefined;
+		}),
+		set: jest.fn(),
+		delete: jest.fn(),
+	} as unknown as CookieStore;
+}
+
+const favoriteItem: FavoriteMeeting = {
+	id: 1,
+	meetingId: 101,
+	userId: 7,
+	createdAt: "2026-04-05T09:00:00.000Z",
+	meeting: {
+		id: 101,
+		teamId: "dev-lucky7",
+		name: "주말 독서 모임",
+		type: "자기계발",
+		region: "서울특별시 광진구",
+		address: "서울특별시 광진구 아차산로 123",
+		latitude: 37.544,
+		longitude: 127.082,
+		dateTime: "2026-04-20T10:00:00.000Z",
+		registrationEnd: "2026-04-18T18:00:00.000Z",
+		capacity: 12,
+		participantCount: 8,
+		image: "https://example.com/favorite.jpg",
+		description: "책 한 권씩 읽고 대화하는 모임",
+		canceledAt: null,
+		confirmedAt: "2026-04-18T19:00:00.000Z",
+		hostId: 3,
+		createdAt: "2026-03-20T10:00:00.000Z",
+		updatedAt: "2026-03-21T10:00:00.000Z",
+		host: {
+			id: 3,
+			name: "모임장",
+			image: null,
+		},
+		isCompleted: false,
+		isJoined: true,
+	},
+};
+
+const favoritesListResponse: FavoritesListResponse = {
+	data: [favoriteItem],
+	nextCursor: null,
+	hasMore: false,
+};
+
+beforeEach(() => {
+	mockedCookies.mockResolvedValue(createCookieStore());
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe("favorites server apis 테스트", () => {
+	describe("getFavorites", () => {
+		it("성공 시 찜 목록 데이터를 반환한다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/favorites`, () => HttpResponse.json(favoritesListResponse)),
+			);
+
+			const result = await getFavorites();
+
+			expect(Array.isArray(result.data)).toBe(true);
+			expect(result.data[0]).toMatchObject({
+				id: favoriteItem.id,
+				meetingId: favoriteItem.meetingId,
+				userId: favoriteItem.userId,
+				createdAt: favoriteItem.createdAt,
+			});
+			expect(result.data[0].meeting).toMatchObject({
+				id: favoriteItem.meeting.id,
+				name: favoriteItem.meeting.name,
+				type: favoriteItem.meeting.type,
+				region: favoriteItem.meeting.region,
+			});
+			expect(result.nextCursor).toBeNull();
+			expect(result.hasMore).toBe(false);
+		});
+
+		it("필터와 날짜 조건을 쿼리스트링으로 변환해 요청한다", async () => {
+			let capturedUrl = "";
+			let authorizationHeader = "";
+
+			mockedCookies.mockResolvedValue(createCookieStore({ accessToken: "access-token" }));
+
+			server.use(
+				http.get(`${TEST_API_BASE}/favorites`, ({ request }) => {
+					capturedUrl = request.url;
+					authorizationHeader = request.headers.get("authorization") ?? "";
+					return HttpResponse.json(favoritesListResponse);
+				}),
+			);
+
+			await getFavorites({
+				type: "자기계발",
+				region: "서울특별시 광진구",
+				dateStart: "2026-04-01",
+				dateEnd: "2026-04-30",
+				sortBy: "participantCount",
+				sortOrder: "asc",
+				cursor: "10",
+				size: 5,
+			});
+
+			const url = new URL(capturedUrl);
+
+			expect(url.searchParams.get("type")).toBe("자기계발");
+			expect(url.searchParams.get("region")).toBe("서울특별시 광진구");
+			expect(url.searchParams.get("dateStart")).toBe("2026-04-01T00:00:00+09:00");
+			expect(url.searchParams.get("dateEnd")).toBe("2026-04-30T23:59:59+09:00");
+			expect(url.searchParams.get("sortBy")).toBe("participantCount");
+			expect(url.searchParams.get("sortOrder")).toBe("asc");
+			expect(url.searchParams.get("cursor")).toBe("10");
+			expect(url.searchParams.get("size")).toBe("5");
+			expect(authorizationHeader).toBe("Bearer access-token");
+		});
+
+		it("URLSearchParams 입력을 파싱해 숫자 size만 요청에 포함한다", async () => {
+			let capturedUrl = "";
+
+			server.use(
+				http.get(`${TEST_API_BASE}/favorites`, ({ request }) => {
+					capturedUrl = request.url;
+					return HttpResponse.json(favoritesListResponse);
+				}),
+			);
+
+			await getFavorites(
+				new URLSearchParams({
+					type: "운동/스포츠",
+					sortBy: "registrationEnd",
+					sortOrder: "desc",
+					size: "3",
+					cursor: "6",
+				}),
+			);
+
+			const url = new URL(capturedUrl);
+
+			expect(url.searchParams.get("type")).toBe("운동/스포츠");
+			expect(url.searchParams.get("sortBy")).toBe("registrationEnd");
+			expect(url.searchParams.get("sortOrder")).toBe("desc");
+			expect(url.searchParams.get("size")).toBe("3");
+			expect(url.searchParams.get("cursor")).toBe("6");
+		});
+
+		it("size가 숫자가 아니면 쿼리에서 제외한다", async () => {
+			let capturedUrl = "";
+
+			server.use(
+				http.get(`${TEST_API_BASE}/favorites`, ({ request }) => {
+					capturedUrl = request.url;
+					return HttpResponse.json(favoritesListResponse);
+				}),
+			);
+
+			await getFavorites(
+				new URLSearchParams({
+					type: "여행",
+					size: "not-a-number",
+				}),
+			);
+
+			const url = new URL(capturedUrl);
+
+			expect(url.searchParams.get("type")).toBe("여행");
+			expect(url.searchParams.has("size")).toBe(false);
+		});
+
+		it("실패 시 응답 메시지와 status를 담은 ApiError를 던진다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/favorites`, () =>
+					HttpResponse.json(
+						{ message: "찜 목록을 불러오지 못했습니다.", code: "FAVORITES_FETCH_FAILED" },
+						{ status: 400 },
+					),
+				),
+			);
+
+			await expect(getFavorites()).rejects.toMatchObject<ApiError>({
+				name: "ApiError",
+				message: "찜 목록을 불러오지 못했습니다.",
+				status: 400,
+				code: "FAVORITES_FETCH_FAILED",
+			});
+		});
+
+		it("에러 응답 바디가 없으면 상태 코드별 기본 메시지로 ApiError를 던진다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/favorites`, () => new HttpResponse(null, { status: 401 })),
+			);
+
+			await expect(getFavorites()).rejects.toMatchObject<ApiError>({
+				name: "ApiError",
+				message: "인증이 필요합니다",
+				status: 401,
+			});
+		});
+	});
+});

--- a/features/favorites/apis/server.test.ts
+++ b/features/favorites/apis/server.test.ts
@@ -5,9 +5,9 @@ jest.mock("next/headers", () => ({
 import { cookies } from "next/headers";
 import { http, HttpResponse } from "msw";
 import { getFavorites } from "@/features/favorites/apis/server";
+import favorites from "@/mocks/data/favorites";
 import { server } from "@/mocks/server";
 import { ApiError } from "@/utils/api";
-import type { FavoriteMeeting, FavoritesListResponse } from "../types";
 
 const TEST_API_BASE = "http://localhost/api";
 
@@ -33,47 +33,6 @@ function createCookieStore(tokens: { accessToken?: string; refreshToken?: string
 	} as unknown as CookieStore;
 }
 
-const favoriteItem: FavoriteMeeting = {
-	id: 1,
-	meetingId: 101,
-	userId: 7,
-	createdAt: "2026-04-05T09:00:00.000Z",
-	meeting: {
-		id: 101,
-		teamId: "dev-lucky7",
-		name: "주말 독서 모임",
-		type: "자기계발",
-		region: "서울특별시 광진구",
-		address: "서울특별시 광진구 아차산로 123",
-		latitude: 37.544,
-		longitude: 127.082,
-		dateTime: "2026-04-20T10:00:00.000Z",
-		registrationEnd: "2026-04-18T18:00:00.000Z",
-		capacity: 12,
-		participantCount: 8,
-		image: "https://example.com/favorite.jpg",
-		description: "책 한 권씩 읽고 대화하는 모임",
-		canceledAt: null,
-		confirmedAt: "2026-04-18T19:00:00.000Z",
-		hostId: 3,
-		createdAt: "2026-03-20T10:00:00.000Z",
-		updatedAt: "2026-03-21T10:00:00.000Z",
-		host: {
-			id: 3,
-			name: "모임장",
-			image: null,
-		},
-		isCompleted: false,
-		isJoined: true,
-	},
-};
-
-const favoritesListResponse: FavoritesListResponse = {
-	data: [favoriteItem],
-	nextCursor: null,
-	hasMore: false,
-};
-
 beforeEach(() => {
 	mockedCookies.mockResolvedValue(createCookieStore());
 });
@@ -85,27 +44,27 @@ afterEach(() => {
 describe("favorites server apis 테스트", () => {
 	describe("getFavorites", () => {
 		it("성공 시 찜 목록 데이터를 반환한다", async () => {
-			server.use(
-				http.get(`${TEST_API_BASE}/favorites`, () => HttpResponse.json(favoritesListResponse)),
-			);
+			const expectedResponse = favorites.list();
+
+			server.use(http.get(`${TEST_API_BASE}/favorites`, () => HttpResponse.json(expectedResponse)));
 
 			const result = await getFavorites();
 
 			expect(Array.isArray(result.data)).toBe(true);
 			expect(result.data[0]).toMatchObject({
-				id: favoriteItem.id,
-				meetingId: favoriteItem.meetingId,
-				userId: favoriteItem.userId,
-				createdAt: favoriteItem.createdAt,
+				id: expectedResponse.data[0].id,
+				meetingId: expectedResponse.data[0].meetingId,
+				userId: expectedResponse.data[0].userId,
+				createdAt: expectedResponse.data[0].createdAt,
 			});
 			expect(result.data[0].meeting).toMatchObject({
-				id: favoriteItem.meeting.id,
-				name: favoriteItem.meeting.name,
-				type: favoriteItem.meeting.type,
-				region: favoriteItem.meeting.region,
+				id: expectedResponse.data[0].meeting.id,
+				name: expectedResponse.data[0].meeting.name,
+				type: expectedResponse.data[0].meeting.type,
+				region: expectedResponse.data[0].meeting.region,
 			});
-			expect(result.nextCursor).toBeNull();
-			expect(result.hasMore).toBe(false);
+			expect(result.nextCursor).toBe(expectedResponse.nextCursor);
+			expect(result.hasMore).toBe(expectedResponse.hasMore);
 		});
 
 		it("필터와 날짜 조건을 쿼리스트링으로 변환해 요청한다", async () => {
@@ -118,7 +77,7 @@ describe("favorites server apis 테스트", () => {
 				http.get(`${TEST_API_BASE}/favorites`, ({ request }) => {
 					capturedUrl = request.url;
 					authorizationHeader = request.headers.get("authorization") ?? "";
-					return HttpResponse.json(favoritesListResponse);
+					return HttpResponse.json(favorites.list());
 				}),
 			);
 
@@ -152,7 +111,7 @@ describe("favorites server apis 테스트", () => {
 			server.use(
 				http.get(`${TEST_API_BASE}/favorites`, ({ request }) => {
 					capturedUrl = request.url;
-					return HttpResponse.json(favoritesListResponse);
+					return HttpResponse.json(favorites.list());
 				}),
 			);
 
@@ -181,7 +140,7 @@ describe("favorites server apis 테스트", () => {
 			server.use(
 				http.get(`${TEST_API_BASE}/favorites`, ({ request }) => {
 					capturedUrl = request.url;
-					return HttpResponse.json(favoritesListResponse);
+					return HttpResponse.json(favorites.list());
 				}),
 			);
 

--- a/features/favorites/apis/server.test.ts
+++ b/features/favorites/apis/server.test.ts
@@ -1,8 +1,4 @@
-jest.mock("next/headers", () => ({
-	cookies: jest.fn(),
-}));
-
-import { cookies } from "next/headers";
+import { createCookieStore, mockedCookies } from "@/mocks/utils/mockHeader";
 import { http, HttpResponse } from "msw";
 import { getFavorites } from "@/features/favorites/apis/server";
 import favorites from "@/mocks/data/favorites";
@@ -10,28 +6,6 @@ import { server } from "@/mocks/server";
 import { ApiError } from "@/utils/api";
 
 const TEST_API_BASE = "http://localhost/api";
-
-const mockedCookies = cookies as jest.MockedFunction<typeof cookies>;
-
-type CookieStore = Awaited<ReturnType<typeof cookies>>;
-
-function createCookieStore(tokens: { accessToken?: string; refreshToken?: string } = {}) {
-	return {
-		get: jest.fn((name: string) => {
-			if (name === "accessToken" && tokens.accessToken) {
-				return { name, value: tokens.accessToken };
-			}
-
-			if (name === "refreshToken" && tokens.refreshToken) {
-				return { name, value: tokens.refreshToken };
-			}
-
-			return undefined;
-		}),
-		set: jest.fn(),
-		delete: jest.fn(),
-	} as unknown as CookieStore;
-}
 
 beforeEach(() => {
 	mockedCookies.mockResolvedValue(createCookieStore());

--- a/features/reviews/apis/server.test.ts
+++ b/features/reviews/apis/server.test.ts
@@ -1,8 +1,4 @@
-jest.mock("next/headers", () => ({
-	cookies: jest.fn(),
-}));
-
-import { cookies } from "next/headers";
+import { createCookieStore, mockedCookies } from "@/mocks/utils/mockHeader";
 import { http, HttpResponse } from "msw";
 import {
 	getReviews,
@@ -15,28 +11,6 @@ import { server } from "@/mocks/server";
 import { ApiError } from "@/utils/api";
 
 const TEST_API_BASE = "http://localhost/api";
-
-const mockedCookies = cookies as jest.MockedFunction<typeof cookies>;
-
-type CookieStore = Awaited<ReturnType<typeof cookies>>;
-
-function createCookieStore(tokens: { accessToken?: string; refreshToken?: string } = {}) {
-	return {
-		get: jest.fn((name: string) => {
-			if (name === "accessToken" && tokens.accessToken) {
-				return { name, value: tokens.accessToken };
-			}
-
-			if (name === "refreshToken" && tokens.refreshToken) {
-				return { name, value: tokens.refreshToken };
-			}
-
-			return undefined;
-		}),
-		set: jest.fn(),
-		delete: jest.fn(),
-	} as unknown as CookieStore;
-}
 
 beforeEach(() => {
 	mockedCookies.mockResolvedValue(createCookieStore());

--- a/features/reviews/apis/server.test.ts
+++ b/features/reviews/apis/server.test.ts
@@ -1,0 +1,313 @@
+jest.mock("next/headers", () => ({
+	cookies: jest.fn(),
+}));
+
+import { cookies } from "next/headers";
+import { http, HttpResponse } from "msw";
+import {
+	getReviews,
+	getReviewsCategoriesStatistics,
+	getReviewsStatistics,
+} from "@/features/reviews/apis/server";
+import { server } from "@/mocks/server";
+import { ApiError } from "@/utils/api";
+import type {
+	RatingSummaryResponse,
+	ReviewCategoryStatistics,
+	ReviewsListItem,
+	ReviewsListResponse,
+} from "../types";
+
+const TEST_API_BASE = "http://localhost/api";
+
+const mockedCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+type CookieStore = Awaited<ReturnType<typeof cookies>>;
+
+function createCookieStore(tokens: { accessToken?: string; refreshToken?: string } = {}) {
+	return {
+		get: jest.fn((name: string) => {
+			if (name === "accessToken" && tokens.accessToken) {
+				return { name, value: tokens.accessToken };
+			}
+
+			if (name === "refreshToken" && tokens.refreshToken) {
+				return { name, value: tokens.refreshToken };
+			}
+
+			return undefined;
+		}),
+		set: jest.fn(),
+		delete: jest.fn(),
+	} as unknown as CookieStore;
+}
+
+const reviewItem: ReviewsListItem = {
+	id: 1,
+	meetingId: 101,
+	userId: 7,
+	score: 5,
+	comment: "정말 만족스러운 모임이었어요.",
+	createdAt: "2026-04-10T09:00:00.000Z",
+	updatedAt: "2026-04-10T09:00:00.000Z",
+	user: {
+		id: 7,
+		email: "tester@example.com",
+		name: "테스터",
+		image: null,
+	},
+	meeting: {
+		id: 101,
+		name: "아침 러닝 모임",
+		type: "운동/스포츠",
+		region: "서울특별시 광진구",
+		image: "https://example.com/review.jpg",
+		dateTime: "2026-04-20T07:00:00.000Z",
+	},
+};
+
+const reviewsListResponse: ReviewsListResponse = {
+	data: [reviewItem],
+	nextCursor: null,
+	hasMore: false,
+};
+
+const ratingSummaryResponse: RatingSummaryResponse = {
+	averageScore: 4.6,
+	totalReviews: 12,
+	oneStar: 0,
+	twoStars: 1,
+	threeStars: 2,
+	fourStars: 4,
+	fiveStars: 5,
+};
+
+const categoryStatisticsResponse: ReviewCategoryStatistics = [
+	{
+		type: "운동/스포츠",
+		averageScore: 4.7,
+		totalReviews: 7,
+		oneStar: 0,
+		twoStars: 0,
+		threeStars: 1,
+		fourStars: 2,
+		fiveStars: 4,
+	},
+	{
+		type: "자기계발",
+		averageScore: 4.3,
+		totalReviews: 5,
+		oneStar: 0,
+		twoStars: 1,
+		threeStars: 1,
+		fourStars: 2,
+		fiveStars: 1,
+	},
+];
+
+beforeEach(() => {
+	mockedCookies.mockResolvedValue(createCookieStore());
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe("reviews server apis 테스트", () => {
+	describe("getReviews", () => {
+		it("성공 시 리뷰 목록 데이터를 반환한다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews`, () => HttpResponse.json(reviewsListResponse)),
+			);
+
+			const result = await getReviews();
+
+			expect(Array.isArray(result.data)).toBe(true);
+			expect(result.data[0]).toMatchObject({
+				id: reviewItem.id,
+				meetingId: reviewItem.meetingId,
+				userId: reviewItem.userId,
+				score: reviewItem.score,
+				comment: reviewItem.comment,
+			});
+			expect(result.nextCursor).toBeNull();
+			expect(result.hasMore).toBe(false);
+		});
+
+		it("필터와 날짜 조건을 쿼리스트링으로 변환해 요청한다", async () => {
+			let capturedUrl = "";
+			let authorizationHeader = "";
+
+			mockedCookies.mockResolvedValue(createCookieStore({ accessToken: "access-token" }));
+
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews`, ({ request }) => {
+					capturedUrl = request.url;
+					authorizationHeader = request.headers.get("authorization") ?? "";
+					return HttpResponse.json(reviewsListResponse);
+				}),
+			);
+
+			await getReviews({
+				type: "운동/스포츠",
+				region: "서울특별시 광진구",
+				dateStart: "2026-04-01",
+				dateEnd: "2026-04-30",
+				registrationEndStart: "2026-03-20",
+				registrationEndEnd: "2026-03-25",
+				sortBy: "dateTime",
+				sortOrder: "asc",
+				cursor: "10",
+				size: 5,
+			});
+
+			const url = new URL(capturedUrl);
+
+			expect(url.searchParams.get("type")).toBe("운동/스포츠");
+			expect(url.searchParams.get("region")).toBe("서울특별시 광진구");
+			expect(url.searchParams.get("dateStart")).toBe("2026-04-01T00:00:00+09:00");
+			expect(url.searchParams.get("dateEnd")).toBe("2026-04-30T23:59:59+09:00");
+			expect(url.searchParams.get("registrationEndStart")).toBe("2026-03-20T00:00:00+09:00");
+			expect(url.searchParams.get("registrationEndEnd")).toBe("2026-03-25T23:59:59+09:00");
+			expect(url.searchParams.get("sortBy")).toBe("dateTime");
+			expect(url.searchParams.get("sortOrder")).toBe("asc");
+			expect(url.searchParams.get("cursor")).toBe("10");
+			expect(url.searchParams.get("size")).toBe("5");
+			expect(authorizationHeader).toBe("Bearer access-token");
+		});
+
+		it("URLSearchParams 입력을 파싱해 숫자 size만 요청에 포함한다", async () => {
+			let capturedUrl = "";
+
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews`, ({ request }) => {
+					capturedUrl = request.url;
+					return HttpResponse.json(reviewsListResponse);
+				}),
+			);
+
+			await getReviews(
+				new URLSearchParams({
+					type: "자기계발",
+					sortBy: "participantCount",
+					sortOrder: "desc",
+					size: "3",
+					cursor: "6",
+				}),
+			);
+
+			const url = new URL(capturedUrl);
+
+			expect(url.searchParams.get("type")).toBe("자기계발");
+			expect(url.searchParams.get("sortBy")).toBe("participantCount");
+			expect(url.searchParams.get("sortOrder")).toBe("desc");
+			expect(url.searchParams.get("size")).toBe("3");
+			expect(url.searchParams.get("cursor")).toBe("6");
+		});
+
+		it("size가 숫자가 아니면 쿼리에서 제외한다", async () => {
+			let capturedUrl = "";
+
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews`, ({ request }) => {
+					capturedUrl = request.url;
+					return HttpResponse.json(reviewsListResponse);
+				}),
+			);
+
+			await getReviews(
+				new URLSearchParams({
+					type: "여행",
+					size: "not-a-number",
+				}),
+			);
+
+			const url = new URL(capturedUrl);
+
+			expect(url.searchParams.get("type")).toBe("여행");
+			expect(url.searchParams.has("size")).toBe(false);
+		});
+
+		it("실패 시 응답 메시지와 status를 담은 ApiError를 던진다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews`, () =>
+					HttpResponse.json(
+						{ message: "리뷰 목록 조회에 실패했습니다.", code: "REVIEWS_FETCH_FAILED" },
+						{ status: 400 },
+					),
+				),
+			);
+
+			await expect(getReviews()).rejects.toMatchObject<ApiError>({
+				name: "ApiError",
+				message: "리뷰 목록 조회에 실패했습니다.",
+				status: 400,
+				code: "REVIEWS_FETCH_FAILED",
+			});
+		});
+	});
+
+	describe("getReviewsStatistics", () => {
+		it("성공 시 전체 평점 요약을 반환한다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews/statistics`, () =>
+					HttpResponse.json(ratingSummaryResponse),
+				),
+			);
+
+			await expect(getReviewsStatistics()).resolves.toEqual(ratingSummaryResponse);
+		});
+
+		it("에러 응답 바디가 없으면 기본 메시지로 ApiError를 던진다", async () => {
+			server.use(
+				http.get(
+					`${TEST_API_BASE}/reviews/statistics`,
+					() => new HttpResponse(null, { status: 500 }),
+				),
+			);
+
+			await expect(getReviewsStatistics()).rejects.toMatchObject<ApiError>({
+				name: "ApiError",
+				message: "리뷰 전체 통계 조회에 실패했습니다.",
+				status: 500,
+			});
+		});
+	});
+
+	describe("getReviewsCategoriesStatistics", () => {
+		it("성공 시 카테고리별 평점 통계를 반환한다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews/categories/statistics`, () =>
+					HttpResponse.json(categoryStatisticsResponse),
+				),
+			);
+
+			const result = await getReviewsCategoriesStatistics();
+
+			expect(Array.isArray(result)).toBe(true);
+			expect(result[0]).toMatchObject({
+				type: categoryStatisticsResponse[0].type,
+				averageScore: categoryStatisticsResponse[0].averageScore,
+				totalReviews: categoryStatisticsResponse[0].totalReviews,
+			});
+			expect(result).toHaveLength(categoryStatisticsResponse.length);
+		});
+
+		it("실패 시 응답 메시지와 status를 담은 ApiError를 던진다", async () => {
+			server.use(
+				http.get(`${TEST_API_BASE}/reviews/categories/statistics`, () =>
+					HttpResponse.json(
+						{ message: "카테고리별 리뷰 통계를 불러오지 못했습니다." },
+						{ status: 503 },
+					),
+				),
+			);
+
+			await expect(getReviewsCategoriesStatistics()).rejects.toMatchObject<ApiError>({
+				name: "ApiError",
+				message: "카테고리별 리뷰 통계를 불러오지 못했습니다.",
+				status: 503,
+			});
+		});
+	});
+});

--- a/features/reviews/apis/server.test.ts
+++ b/features/reviews/apis/server.test.ts
@@ -9,14 +9,10 @@ import {
 	getReviewsCategoriesStatistics,
 	getReviewsStatistics,
 } from "@/features/reviews/apis/server";
+import reviews from "@/mocks/data/reviews";
+import { CATEGORY_STATISTICS, STATISTICS } from "@/mocks/data/reviews/fixtures";
 import { server } from "@/mocks/server";
 import { ApiError } from "@/utils/api";
-import type {
-	RatingSummaryResponse,
-	ReviewCategoryStatistics,
-	ReviewsListItem,
-	ReviewsListResponse,
-} from "../types";
 
 const TEST_API_BASE = "http://localhost/api";
 
@@ -42,69 +38,6 @@ function createCookieStore(tokens: { accessToken?: string; refreshToken?: string
 	} as unknown as CookieStore;
 }
 
-const reviewItem: ReviewsListItem = {
-	id: 1,
-	meetingId: 101,
-	userId: 7,
-	score: 5,
-	comment: "정말 만족스러운 모임이었어요.",
-	createdAt: "2026-04-10T09:00:00.000Z",
-	updatedAt: "2026-04-10T09:00:00.000Z",
-	user: {
-		id: 7,
-		email: "tester@example.com",
-		name: "테스터",
-		image: null,
-	},
-	meeting: {
-		id: 101,
-		name: "아침 러닝 모임",
-		type: "운동/스포츠",
-		region: "서울특별시 광진구",
-		image: "https://example.com/review.jpg",
-		dateTime: "2026-04-20T07:00:00.000Z",
-	},
-};
-
-const reviewsListResponse: ReviewsListResponse = {
-	data: [reviewItem],
-	nextCursor: null,
-	hasMore: false,
-};
-
-const ratingSummaryResponse: RatingSummaryResponse = {
-	averageScore: 4.6,
-	totalReviews: 12,
-	oneStar: 0,
-	twoStars: 1,
-	threeStars: 2,
-	fourStars: 4,
-	fiveStars: 5,
-};
-
-const categoryStatisticsResponse: ReviewCategoryStatistics = [
-	{
-		type: "운동/스포츠",
-		averageScore: 4.7,
-		totalReviews: 7,
-		oneStar: 0,
-		twoStars: 0,
-		threeStars: 1,
-		fourStars: 2,
-		fiveStars: 4,
-	},
-	{
-		type: "자기계발",
-		averageScore: 4.3,
-		totalReviews: 5,
-		oneStar: 0,
-		twoStars: 1,
-		threeStars: 1,
-		fourStars: 2,
-		fiveStars: 1,
-	},
-];
-
 beforeEach(() => {
 	mockedCookies.mockResolvedValue(createCookieStore());
 });
@@ -116,22 +49,22 @@ afterEach(() => {
 describe("reviews server apis 테스트", () => {
 	describe("getReviews", () => {
 		it("성공 시 리뷰 목록 데이터를 반환한다", async () => {
-			server.use(
-				http.get(`${TEST_API_BASE}/reviews`, () => HttpResponse.json(reviewsListResponse)),
-			);
+			const expectedResponse = reviews.list();
+
+			server.use(http.get(`${TEST_API_BASE}/reviews`, () => HttpResponse.json(expectedResponse)));
 
 			const result = await getReviews();
 
 			expect(Array.isArray(result.data)).toBe(true);
 			expect(result.data[0]).toMatchObject({
-				id: reviewItem.id,
-				meetingId: reviewItem.meetingId,
-				userId: reviewItem.userId,
-				score: reviewItem.score,
-				comment: reviewItem.comment,
+				id: expectedResponse.data[0].id,
+				meetingId: expectedResponse.data[0].meetingId,
+				userId: expectedResponse.data[0].userId,
+				score: expectedResponse.data[0].score,
+				comment: expectedResponse.data[0].comment,
 			});
-			expect(result.nextCursor).toBeNull();
-			expect(result.hasMore).toBe(false);
+			expect(result.nextCursor).toBe(expectedResponse.nextCursor);
+			expect(result.hasMore).toBe(expectedResponse.hasMore);
 		});
 
 		it("필터와 날짜 조건을 쿼리스트링으로 변환해 요청한다", async () => {
@@ -144,7 +77,7 @@ describe("reviews server apis 테스트", () => {
 				http.get(`${TEST_API_BASE}/reviews`, ({ request }) => {
 					capturedUrl = request.url;
 					authorizationHeader = request.headers.get("authorization") ?? "";
-					return HttpResponse.json(reviewsListResponse);
+					return HttpResponse.json(reviews.list());
 				}),
 			);
 
@@ -182,7 +115,7 @@ describe("reviews server apis 테스트", () => {
 			server.use(
 				http.get(`${TEST_API_BASE}/reviews`, ({ request }) => {
 					capturedUrl = request.url;
-					return HttpResponse.json(reviewsListResponse);
+					return HttpResponse.json(reviews.list());
 				}),
 			);
 
@@ -211,7 +144,7 @@ describe("reviews server apis 테스트", () => {
 			server.use(
 				http.get(`${TEST_API_BASE}/reviews`, ({ request }) => {
 					capturedUrl = request.url;
-					return HttpResponse.json(reviewsListResponse);
+					return HttpResponse.json(reviews.list());
 				}),
 			);
 
@@ -250,12 +183,10 @@ describe("reviews server apis 테스트", () => {
 	describe("getReviewsStatistics", () => {
 		it("성공 시 전체 평점 요약을 반환한다", async () => {
 			server.use(
-				http.get(`${TEST_API_BASE}/reviews/statistics`, () =>
-					HttpResponse.json(ratingSummaryResponse),
-				),
+				http.get(`${TEST_API_BASE}/reviews/statistics`, () => HttpResponse.json(STATISTICS)),
 			);
 
-			await expect(getReviewsStatistics()).resolves.toEqual(ratingSummaryResponse);
+			await expect(getReviewsStatistics()).resolves.toEqual(STATISTICS);
 		});
 
 		it("에러 응답 바디가 없으면 기본 메시지로 ApiError를 던진다", async () => {
@@ -278,7 +209,7 @@ describe("reviews server apis 테스트", () => {
 		it("성공 시 카테고리별 평점 통계를 반환한다", async () => {
 			server.use(
 				http.get(`${TEST_API_BASE}/reviews/categories/statistics`, () =>
-					HttpResponse.json(categoryStatisticsResponse),
+					HttpResponse.json(CATEGORY_STATISTICS),
 				),
 			);
 
@@ -286,11 +217,11 @@ describe("reviews server apis 테스트", () => {
 
 			expect(Array.isArray(result)).toBe(true);
 			expect(result[0]).toMatchObject({
-				type: categoryStatisticsResponse[0].type,
-				averageScore: categoryStatisticsResponse[0].averageScore,
-				totalReviews: categoryStatisticsResponse[0].totalReviews,
+				type: CATEGORY_STATISTICS[0].type,
+				averageScore: CATEGORY_STATISTICS[0].averageScore,
+				totalReviews: CATEGORY_STATISTICS[0].totalReviews,
 			});
-			expect(result).toHaveLength(categoryStatisticsResponse.length);
+			expect(result).toHaveLength(CATEGORY_STATISTICS.length);
 		});
 
 		it("실패 시 응답 메시지와 status를 담은 ApiError를 던진다", async () => {

--- a/mocks/data/favorites/fixtures.ts
+++ b/mocks/data/favorites/fixtures.ts
@@ -1,0 +1,5 @@
+export const FAVORITED_AT_BY_MEETING_ID: Record<number, string> = {
+	2: "2026-02-18T09:00:00.000Z",
+	4: "2026-03-02T08:30:00.000Z",
+	7: "2026-03-08T07:45:00.000Z",
+};

--- a/mocks/data/favorites/helpers.ts
+++ b/mocks/data/favorites/helpers.ts
@@ -1,0 +1,139 @@
+import type {
+	FavoriteMeeting,
+	FavoritesListRequest,
+	FavoritesListResponse,
+} from "@/features/favorites/types";
+
+const SORT_ORDER_VALUES = new Set<string>(["asc", "desc"]);
+
+type FavoriteListSortKey = NonNullable<FavoritesListRequest["sortBy"]>;
+
+const FAVORITE_LIST_SORT_KEYS = new Set<FavoriteListSortKey>([
+	"createdAt",
+	"meetingCreatedAt",
+	"dateTime",
+	"registrationEnd",
+	"participantCount",
+]);
+
+function toTimestamp(value: string): number | null {
+	const timestamp = new Date(value).getTime();
+	return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function parseFavoritesListRequest(url: URL): FavoritesListRequest {
+	const num = (key: string): number | undefined => {
+		const value = url.searchParams.get(key);
+		if (value == null || value === "") return undefined;
+
+		const parsed = Number(value);
+		return Number.isFinite(parsed) ? parsed : undefined;
+	};
+
+	const str = (key: string): string | undefined => {
+		const value = url.searchParams.get(key);
+		return value != null && value !== "" ? value : undefined;
+	};
+
+	return {
+		type: str("type"),
+		region: str("region"),
+		dateStart: str("dateStart"),
+		dateEnd: str("dateEnd"),
+		sortBy: str("sortBy") as FavoritesListRequest["sortBy"],
+		sortOrder: str("sortOrder") as FavoritesListRequest["sortOrder"],
+		cursor: str("cursor"),
+		size: num("size"),
+	};
+}
+
+export function buildFavoritesListResponse(
+	rows: readonly FavoriteMeeting[],
+	params: FavoritesListRequest = {},
+): FavoritesListResponse {
+	let list = [...rows];
+
+	if (params.type) {
+		list = list.filter((favorite) => favorite.meeting.type === params.type);
+	}
+
+	if (params.region) {
+		const needle = params.region.trim();
+		list = list.filter(
+			(favorite) =>
+				favorite.meeting.region.includes(needle) || needle.includes(favorite.meeting.region),
+		);
+	}
+
+	if (params.dateStart) {
+		const dateStart = new Date(params.dateStart).getTime();
+		if (Number.isFinite(dateStart)) {
+			list = list.filter((favorite) => {
+				const meetingTime = toTimestamp(favorite.meeting.dateTime);
+				return meetingTime == null || meetingTime >= dateStart;
+			});
+		}
+	}
+
+	if (params.dateEnd) {
+		const dateEnd = new Date(params.dateEnd).getTime();
+		if (Number.isFinite(dateEnd)) {
+			list = list.filter((favorite) => {
+				const meetingTime = toTimestamp(favorite.meeting.dateTime);
+				return meetingTime == null || meetingTime <= dateEnd;
+			});
+		}
+	}
+
+	const sortKeyRaw = params.sortBy;
+	const sortBy: FavoriteListSortKey =
+		sortKeyRaw && FAVORITE_LIST_SORT_KEYS.has(sortKeyRaw) ? sortKeyRaw : "createdAt";
+	const sortOrder =
+		params.sortOrder && SORT_ORDER_VALUES.has(params.sortOrder) ? params.sortOrder : "desc";
+	const direction = sortOrder === "desc" ? -1 : 1;
+
+	list.sort((a, b) => {
+		let aValue: number;
+		let bValue: number;
+
+		if (sortBy === "meetingCreatedAt") {
+			aValue = toTimestamp(a.meeting.createdAt) ?? 0;
+			bValue = toTimestamp(b.meeting.createdAt) ?? 0;
+		} else if (sortBy === "dateTime") {
+			aValue = toTimestamp(a.meeting.dateTime) ?? 0;
+			bValue = toTimestamp(b.meeting.dateTime) ?? 0;
+		} else if (sortBy === "registrationEnd") {
+			aValue = toTimestamp(a.meeting.registrationEnd) ?? 0;
+			bValue = toTimestamp(b.meeting.registrationEnd) ?? 0;
+		} else if (sortBy === "participantCount") {
+			aValue = a.meeting.participantCount;
+			bValue = b.meeting.participantCount;
+		} else {
+			aValue = toTimestamp(a.createdAt) ?? 0;
+			bValue = toTimestamp(b.createdAt) ?? 0;
+		}
+
+		if (aValue === bValue) return a.id - b.id;
+		return (aValue - bValue) * direction;
+	});
+
+	const limit = params.size != null && params.size > 0 ? Math.min(params.size, 100) : 10;
+	let offset = 0;
+
+	if (params.cursor != null && params.cursor !== "") {
+		const parsedCursor = Number(params.cursor);
+		if (Number.isFinite(parsedCursor) && parsedCursor >= 0) {
+			offset = Math.floor(parsedCursor);
+		}
+	}
+
+	const pageRows = list.slice(offset, offset + limit);
+	const nextOffset = offset + pageRows.length;
+	const hasMore = nextOffset < list.length;
+
+	return {
+		data: pageRows,
+		nextCursor: hasMore ? String(nextOffset) : null,
+		hasMore,
+	};
+}

--- a/mocks/data/favorites/index.ts
+++ b/mocks/data/favorites/index.ts
@@ -1,0 +1,93 @@
+import type {
+	FavoriteMeeting,
+	FavoritesListRequest,
+	FavoritesListResponse,
+} from "@/features/favorites/types";
+import { buildFavoritesListResponse } from "./helpers";
+import { FAVORITED_AT_BY_MEETING_ID } from "./fixtures";
+import { MEETINGS } from "../meetings/fixtures";
+
+const CURRENT_USER_ID = 1;
+
+type MeetingRow = (typeof MEETINGS.data)[number];
+
+function getFavoriteCreatedAt(meeting: MeetingRow) {
+	return FAVORITED_AT_BY_MEETING_ID[meeting.id] ?? meeting.updatedAt ?? meeting.createdAt;
+}
+
+function toFavoriteMeeting(meeting: MeetingRow): FavoriteMeeting {
+	const {
+		id,
+		teamId,
+		name,
+		type,
+		region,
+		address,
+		latitude,
+		longitude,
+		dateTime,
+		registrationEnd,
+		capacity,
+		participantCount,
+		image,
+		description,
+		canceledAt,
+		confirmedAt,
+		hostId,
+		createdAt,
+		updatedAt,
+		host,
+		isCompleted,
+		isJoined,
+	} = meeting;
+
+	return {
+		id,
+		meetingId: id,
+		userId: CURRENT_USER_ID,
+		createdAt: getFavoriteCreatedAt(meeting),
+		meeting: {
+			id,
+			teamId,
+			name,
+			type,
+			region,
+			address,
+			latitude,
+			longitude,
+			dateTime,
+			registrationEnd,
+			capacity,
+			participantCount,
+			image,
+			description,
+			canceledAt,
+			confirmedAt,
+			hostId,
+			createdAt,
+			updatedAt,
+			host,
+			isCompleted,
+			isJoined,
+		},
+	};
+}
+
+function getFavoriteRows(): FavoriteMeeting[] {
+	return MEETINGS.data.filter((meeting) => meeting.isFavorited).map(toFavoriteMeeting);
+}
+
+function listFavorites(params: FavoritesListRequest = {}): FavoritesListResponse {
+	return buildFavoritesListResponse(getFavoriteRows(), params);
+}
+
+function getFavoritesCount() {
+	return getFavoriteRows().length;
+}
+
+const favorites = {
+	list: listFavorites,
+	getCount: getFavoritesCount,
+};
+
+export default favorites;

--- a/mocks/handlers/favorites.ts
+++ b/mocks/handlers/favorites.ts
@@ -1,9 +1,17 @@
 import { http, HttpResponse } from "msw";
 import { BASE_URL } from "../constants";
+import favorites from "../data/favorites";
+import { parseFavoritesListRequest } from "../data/favorites/helpers";
 
 export const favoritesHandlers = [
+	// GET /api/favorites
+	http.get(`${BASE_URL}/favorites`, ({ request }) => {
+		const url = new URL(request.url);
+		return HttpResponse.json(favorites.list(parseFavoritesListRequest(url)));
+	}),
+
 	// GET /api/favorites/count
 	http.get(`${BASE_URL}/favorites/count`, () => {
-		return HttpResponse.json({ count: 1 });
+		return HttpResponse.json({ count: favorites.getCount() });
 	}),
 ];

--- a/mocks/utils/mockHeader.ts
+++ b/mocks/utils/mockHeader.ts
@@ -1,0 +1,31 @@
+jest.mock("next/headers", () => ({
+	cookies: jest.fn(),
+}));
+
+import { cookies } from "next/headers";
+
+export type MockCookieStore = Awaited<ReturnType<typeof cookies>>;
+
+/**
+ * 서버 API 테스트에서 `next/headers`의 `cookies()`를 일관되게 mock 하기 위한 유틸.
+ * access/refresh token 유무를 제어해 `serverFetch`가 읽는 쿠키 상태를 재현한다.
+ */
+export const mockedCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+export function createCookieStore(tokens: { accessToken?: string; refreshToken?: string } = {}) {
+	return {
+		get: jest.fn((name: string) => {
+			if (name === "accessToken" && tokens.accessToken) {
+				return { name, value: tokens.accessToken };
+			}
+
+			if (name === "refreshToken" && tokens.refreshToken) {
+				return { name, value: tokens.refreshToken };
+			}
+
+			return undefined;
+		}),
+		set: jest.fn(),
+		delete: jest.fn(),
+	} as unknown as MockCookieStore;
+}


### PR DESCRIPTION
## 🛠️ 설명 (Description)

favorites mock data와 favoritesHandlers 추가하고 
MSW 기반으로 리뷰/찜 서버 API 테스트를 추가했습니다.

- 리뷰/찜 목록 조회 성공 케이스뿐 아니라, 필터/정렬/날짜 파라미터가 실제 요청 쿼리로 올바르게 변환되는지와 실패 시 `ApiError`로 정상 매핑되는지를 검증했습니다.  
또한 `next/headers`의 `cookies()` 모킹을 `mocks/utils/mockHeader.ts`로 분리해 리뷰/찜 서버 API 테스트에서 공통으로 재사용하도록 정리했습니다.

## 📝 변경 사항 요약 (Summary)

- MSW 기반 리뷰/찜 서버 API 테스트 추가
   - 찜한 모임 목록 조회 api 테스트를 위해 `mocks/data/favorites`와`mocks/handlers/favorites`를 추가해 기존 mock 구조와 동일한 방식으로 재구성했습니다.  
- 리뷰/찜 목록 조회 성공 응답 검증
- 객체 인자 및 `URLSearchParams` 입력에 대한 쿼리 변환 검증
- 날짜 범위, 정렬, 커서, `size` 파라미터 직렬화 검증
- `serverFetch`가 읽는 cookie 상태와 Authorization 헤더 주입 검증
    - `mocks/utils/mockHeader.ts` 추가로 `next/headers` mock 유틸 공통화했습니다.
- 에러 응답 시 `ApiError` 매핑 및 기본 메시지 fallback 검증

## 💁 변경 사항 이유 (Why)

- 서버 API 레이어의 회귀를 빠르게 감지하기 위해
- 검색/필터 파라미터 직렬화 오류를 사전에 방지하기 위해
- 백엔드 에러 응답과 기본 에러 메시지 매핑이 기대대로 동작하는지 보장하기 위해

## ✅ 테스트 계획 (Test Plan)
> reviews 테스트
```bash
pnpm test -- --runInBand features/reviews/apis/server.test.ts
```
> favorites 테스트
```bash
pnpm test -- --runInBand features/favorites/apis/server.test.ts
```
> reviews, favorites 한번에 테스트
```bash
pnpm test -- --runInBand features/reviews/apis/server.test.ts features/favorites/apis/server.test.ts
```
- 결과: `2`개 테스트 스위트, `15`개 테스트 통과


- MSW 기반 서버 API 테스트 수행
- 리뷰/찜 목록 조회 성공 응답 파싱 검증
- 객체 인자 및 `URLSearchParams` 입력에 대한 쿼리스트링 변환 검증
- 날짜 범위 문자열(`+09:00` suffix 포함) 직렬화 검증
- 숫자가 아닌 `size` 값 제외 처리 검증
- cookie 기반 Authorization 헤더 주입 검증
- 에러 응답 시 `ApiError` 변환 및 기본 메시지 처리 검증
- 리뷰 통계 API 성공/실패 케이스 검증

## 🔗 관련 이슈 (Related Issues)

- Closed #348

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [ ] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

- `mocks/utils/mockHeader.ts`는 `next/headers`의 `cookies()`를 공통으로 mock 하기 위한 유틸입니다.
- 날짜 파라미터 검증은 현재 유틸 구현이 timezone 계산이 아니라 `+09:00` 고정 문자열을 append하는 구조라 `toBe(...)`로 전체 문자열을 엄격히 검증했습니다.

## ➕ 추가 정보 (Additional Information)
