### PR TITLE
refactor(mypage): 마이페이지 api 에러처리 리팩토링 및 scroll 이슈 수정

### DIFF
--- a/features/mypage/MyTab/TabWrapper/index.tsx
+++ b/features/mypage/MyTab/TabWrapper/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import PageTabs from "@/components/ui/PageTabs";
 import { useQueryParams } from "@/hooks/useQueryParams";
 import JoinedMeetingListWrapper from "../../JoinedMeetingList";
@@ -17,17 +17,14 @@ const TAB_STICKY_OFFSET = {
 	sm: 48,
 	md: 88,
 } as const;
+
 // STICKY 이후 스크롤 시 스타일 적용 임계값
-const THRESHOLD = {
-	lg: 20,
-	md: 320,
-	sm: 220,
-} as const;
+const SCROLL_CORRECTION = 20;
 
 const STYLE = {
 	tabWrapper: "sticky top-12 z-10 bg-gray-50 md:top-22 lg:static",
 	scroll:
-		"h-4 shadow-[0_13px_16px_rgba(0,0,0,0.08)] overflow-hidden absolute bottom-px left-0 z-0 block w-full",
+		"h-4 shadow-[0_13px_16px_rgba(0,0,0,0.15)] overflow-hidden absolute bottom-px left-0 z-0 block w-full",
 };
 
 const TAB_ITEMS = [
@@ -49,16 +46,54 @@ export default function TabWrapper() {
 	const isLg = useMediaQuery(MEDIA_QUERY_LG);
 	const isMd = useMediaQuery(MEDIA_QUERY_MD);
 	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+	const [scrollThreshold, setScrollThreshold] = useState(0);
 	const [activeTab, setActiveTab] = useState<TabId>(isTabId(tabQuery) ? tabQuery : TAB_ITEMS[0].id);
 	const tabAnchorRef = useRef<HTMLDivElement>(null);
 	const tabRef = useRef<HTMLDivElement>(null);
 	const contentRef = useRef<HTMLDivElement>(null);
-	const threshold = isLg ? THRESHOLD.lg : isMd ? THRESHOLD.md : THRESHOLD.sm;
 
 	const isVisible = useScrollVisibility({
-		threshold,
+		threshold: scrollThreshold,
 		targetRef: isLg ? contentRef : undefined,
 	});
+
+	const stickyOffset = isMd ? TAB_STICKY_OFFSET.md : TAB_STICKY_OFFSET.sm;
+
+	function getTabStickyScrollTop() {
+		const anchorTop =
+			(tabAnchorRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY - stickyOffset;
+
+		return Math.max(anchorTop, 0);
+	}
+
+	function scrollToTabContentTop() {
+		if (isLg) {
+			contentRef.current?.scrollTo({ top: 0, behavior: "auto" });
+			return;
+		}
+		const tabTop = tabRef.current?.getBoundingClientRect().top ?? 0;
+		if (tabTop <= stickyOffset + 1) {
+			window.scrollTo({ top: getTabStickyScrollTop(), behavior: "smooth" });
+		}
+	}
+
+	function handleTabChange({ id }: { id: string }) {
+		if (!isTabId(id)) return;
+
+		setIsDropdownOpen(false);
+		scrollToTabContentTop();
+		setActiveTab(id);
+		set({ tab: id });
+	}
+
+	// 반응형에 따른 스크롤 이벤트
+	useLayoutEffect(() => {
+		if (isLg) {
+			setScrollThreshold(SCROLL_CORRECTION);
+			return;
+		}
+		setScrollThreshold(getTabStickyScrollTop() + SCROLL_CORRECTION);
+	}, [isLg, isMd]);
 
 	// 잘못된 URL 수정
 	useEffect(() => {
@@ -82,37 +117,13 @@ export default function TabWrapper() {
 		WrittenReviewList: <WrittenReviewListWrapper onDropdownOpenChange={setIsDropdownOpen} />,
 	};
 
-	function scrollToTabContentTop() {
-		if (isLg) {
-			contentRef.current?.scrollTo({ top: 0, behavior: "auto" });
-			return;
-		}
-
-		const stickyOffset = isMd ? TAB_STICKY_OFFSET.md : TAB_STICKY_OFFSET.sm;
-		const anchorTop =
-			(tabAnchorRef.current?.getBoundingClientRect().top ?? 0) + window.scrollY - stickyOffset;
-
-		window.scrollTo({
-			top: Math.max(anchorTop, 0),
-			behavior: "smooth",
-		});
-	}
 	return (
 		<div className="min-w-0 grow">
 			<div ref={tabAnchorRef} />
 			<div className={STYLE.tabWrapper} ref={tabRef}>
 				<div className={cn("relative z-1")}>
 					<div className={isVisible ? STYLE.scroll : ""} />
-					<PageTabs
-						key={activeTab}
-						defaultId={activeTab}
-						onChange={({ id }) => {
-							const nextTab = id as TabId;
-							setIsDropdownOpen(false);
-							scrollToTabContentTop();
-							setActiveTab(nextTab);
-							set({ tab: id });
-						}}>
+					<PageTabs key={activeTab} defaultId={activeTab} onChange={handleTabChange}>
 						{TAB_ITEMS.map((tabItem) => (
 							<PageTabs.Item
 								key={tabItem.id}

--- a/features/mypage/apis.ts
+++ b/features/mypage/apis.ts
@@ -176,53 +176,6 @@ export async function deleteReviews({ reviewId }: { reviewId: number }): Promise
 	await throwApiError(res, "리뷰 삭제에 실패했습니다.");
 }
 
-// 찜 추가
-export async function postMeetingsFavorites(meetingId: number): Promise<void> {
-	const res = await clientFetch(`/meetings/${meetingId}/favorites`, {
-		method: "POST",
-	});
-	await throwApiError(res, "찜 추가에 실패했습니다.");
-}
-
-// 찜 해제
-export async function deleteMeetingsFavorites(meetingId: number): Promise<void> {
-	const res = await clientFetch(`/meetings/${meetingId}/favorites`, {
-		method: "DELETE",
-	});
-	await throwApiError(res, "찜 해제에 실패했습니다.");
-}
-
-// image 업로드
-export async function uploadProfileImage(file: File): Promise<string> {
-	// presigned URL
-	const presignedResponse = await clientFetch("/images/presigned", {
-		method: "POST",
-		body: JSON.stringify({
-			fileName: file.name,
-			contentType: file.type,
-		}),
-	});
-
-	await throwApiError(presignedResponse, "이미지 업로드 URL 발급에 실패했습니다.");
-
-	// public URL
-	const { presignedUrl, publicUrl } = await presignedResponse.json();
-
-	const uploadResponse = await fetch(presignedUrl, {
-		method: "PUT",
-		headers: {
-			"Content-Type": file.type,
-		},
-		body: file,
-	});
-
-	if (!uploadResponse.ok) {
-		throw new Error("이미지 업로드에 실패했습니다.");
-	}
-
-	return publicUrl;
-}
-
 // 유저 프로필
 export async function patchUsersMe(user: PatchUserProfilePayload): Promise<User> {
 	const res = await clientFetch("/users/me", {

--- a/features/mypage/apis.ts
+++ b/features/mypage/apis.ts
@@ -16,6 +16,7 @@ import {
 import { clientFetch } from "@/libs/clientFetch";
 import { mapJoinedMeeting, mapMeReviews, mapUsersMeMeetings } from "./mapper";
 import { throwApiError } from "@/utils/api";
+import { MYPAGE_MESSAGES } from "./message";
 
 export interface BaseListParams {
 	sortBy?: string;
@@ -68,9 +69,7 @@ async function mypageFetch<ApiItem, MappedItem, TParams extends object>(
 
 	const res = await clientFetch(url);
 
-	if (!res.ok) {
-		throw new Error(`목록 조회 실패: ${res.status}`);
-	}
+	await throwApiError(res, MYPAGE_MESSAGES.fetchListError);
 
 	const json = await res.json();
 
@@ -123,7 +122,11 @@ export async function patchMeetingsStatus({
 		body: JSON.stringify({ status }),
 	});
 
-	await throwApiError(res, "모임 상태 변경에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.patchMeetingStatusError, {
+		statusMessages: {
+			404: MYPAGE_MESSAGES.deleteMeetingNotFoundError,
+		},
+	});
 }
 
 // 모임 삭제 하기
@@ -132,7 +135,11 @@ export async function deleteMeetings({ meetingId }: { meetingId: number }): Prom
 		method: "DELETE",
 	});
 
-	await throwApiError(res, "모임 삭제에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.deleteMeetingError, {
+		statusMessages: {
+			404: MYPAGE_MESSAGES.deleteMeetingNotFoundError,
+		},
+	});
 }
 
 // 모임 참여 취소 하기
@@ -141,7 +148,7 @@ export async function deleteMeetingsJoin({ meetingId }: { meetingId: number }): 
 		method: "DELETE",
 	});
 
-	await throwApiError(res, "모임 참여 취소에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.deleteMeetingJoinError);
 }
 
 // 리뷰 작성 하기
@@ -153,7 +160,7 @@ export async function postMeetingsReviews({
 		method: "POST",
 		body: JSON.stringify(reviewFormValues),
 	});
-	await throwApiError(res, "리뷰 작성에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.createReviewError);
 }
 
 // 리뷰 수정 하기
@@ -165,7 +172,7 @@ export async function patchReviews({
 		method: "PATCH",
 		body: JSON.stringify(reviewFormValues),
 	});
-	await throwApiError(res, "리뷰 수정에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.updateReviewError);
 }
 
 // 리뷰 삭제 하기
@@ -173,7 +180,7 @@ export async function deleteReviews({ reviewId }: { reviewId: number }): Promise
 	const res = await clientFetch(`/reviews/${reviewId}`, {
 		method: "DELETE",
 	});
-	await throwApiError(res, "리뷰 삭제에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.deleteReviewError);
 }
 
 // 유저 프로필
@@ -182,7 +189,7 @@ export async function patchUsersMe(user: PatchUserProfilePayload): Promise<User>
 		method: "PATCH",
 		body: JSON.stringify(user),
 	});
-	await throwApiError(res, "프로필 수정에 실패했습니다.");
+	await throwApiError(res, MYPAGE_MESSAGES.updateProfileError);
 
 	return res.json();
 }

--- a/features/mypage/message.ts
+++ b/features/mypage/message.ts
@@ -1,0 +1,23 @@
+const RETRY_LATER_SUFFIX = "\n잠시 후 다시 시도해주세요.";
+
+export const MYPAGE_MESSAGES = {
+	fetchListError: "목록 조회에 실패했습니다." + RETRY_LATER_SUFFIX,
+	patchMeetingStatusSuccess: (status: "CONFIRMED" | "CANCELED") =>
+		`모임이 ${status === "CONFIRMED" ? "확정" : "취소"}되었습니다.`,
+	patchMeetingStatusError: "모임 상태 변경에 실패했습니다." + RETRY_LATER_SUFFIX,
+	deleteMeetingSuccess: "모임이 삭제 되었습니다.",
+	deleteMeetingError: "모임 삭제에 실패했습니다." + RETRY_LATER_SUFFIX,
+	deleteMeetingNotFoundError: "이미 삭제된 모임입니다.",
+	deleteMeetingJoinSuccess: "모임 예약이 취소 되었습니다.",
+	deleteMeetingJoinError: "모임 참여 취소에 실패했습니다." + RETRY_LATER_SUFFIX,
+	createReviewSuccess: "리뷰가 작성 되었습니다.",
+	createReviewError: "리뷰 작성에 실패했습니다." + RETRY_LATER_SUFFIX,
+	updateReviewSuccess: "리뷰가 수정 되었습니다.",
+	updateReviewError: "리뷰 수정에 실패했습니다." + RETRY_LATER_SUFFIX,
+	deleteReviewSuccess: "리뷰가 삭제 되었습니다.",
+	deleteReviewError: "리뷰 삭제에 실패했습니다." + RETRY_LATER_SUFFIX,
+	updateProfileSuccess: "프로필이 수정되었습니다.",
+	updateProfileError: "프로필 수정에 실패했습니다." + RETRY_LATER_SUFFIX,
+	uploadProfileImageSuccess: "이미지가 업로드되었습니다.",
+	uploadProfileImageError: "이미지 업로드에 실패했습니다." + RETRY_LATER_SUFFIX,
+};

--- a/features/mypage/mutations.ts
+++ b/features/mypage/mutations.ts
@@ -62,7 +62,7 @@ export function usePatchUsersMe(options?: UsePatchUsersMeOptions) {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.updateProfileError),
 				status: "error",
 			});
 		},
@@ -92,7 +92,7 @@ export function usePatchMeetingsStatus() {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.patchMeetingStatusError),
 				status: "error",
 			});
 		},
@@ -121,7 +121,7 @@ export function useDeleteMeetings() {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.deleteMeetingError),
 				status: "error",
 			});
 		},
@@ -154,7 +154,7 @@ export function useDeleteMeetingsJoin() {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.deleteMeetingJoinError),
 				status: "error",
 			});
 		},
@@ -180,7 +180,7 @@ export function usePostMeetingsReviews() {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.createReviewError),
 				status: "error",
 			});
 		},
@@ -206,7 +206,7 @@ export function usePatchReviews() {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.updateReviewError),
 				status: "error",
 			});
 		},
@@ -232,7 +232,7 @@ export function useDeleteReviews() {
 
 		onError: (error) => {
 			handleShowToast({
-				message: error.message,
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.deleteReviewError),
 				status: "error",
 			});
 		},

--- a/features/mypage/mutations.ts
+++ b/features/mypage/mutations.ts
@@ -16,6 +16,8 @@ import { headerQueryKeys } from "@/features/shared/queryKeys/header";
 import { meetupQueryKeys } from "@/features/shared/queryKeys/meetup";
 import { reviewsQueryKeys } from "@/features/shared/queryKeys/reviews";
 import { uploadImage } from "@/apis/images";
+import { getUserErrorMessage } from "@/utils/api";
+import { MYPAGE_MESSAGES } from "@/features/mypage/message";
 
 interface UsePatchUsersMeOptions {
 	onSuccessBeforeSync?: () => void;
@@ -28,14 +30,14 @@ export function useUploadProfileImage() {
 
 		onSuccess: () => {
 			handleShowToast({
-				message: "이미지가 업로드되었습니다.",
+				message: MYPAGE_MESSAGES.uploadProfileImageSuccess,
 				status: "success",
 			});
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: "이미지 업로드에 실패했습니다.\n잠시 후 다시 시도해주세요.",
+				message: getUserErrorMessage(error, MYPAGE_MESSAGES.uploadProfileImageError),
 				status: "error",
 			});
 		},
@@ -52,15 +54,15 @@ export function usePatchUsersMe(options?: UsePatchUsersMeOptions) {
 		onSuccess: () => {
 			options?.onSuccessBeforeSync?.();
 			handleShowToast({
-				message: "프로필이 수정되었습니다.",
+				message: MYPAGE_MESSAGES.updateProfileSuccess,
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: authQueryKeys.me });
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: "프로필 수정에 실패했습니다.\n잠시 후 다시 시도해주세요.",
+				message: error.message,
 				status: "error",
 			});
 		},
@@ -76,10 +78,8 @@ export function usePatchMeetingsStatus() {
 		mutationFn: patchMeetingsStatus,
 
 		onSuccess: (_data, variables) => {
-			const isConfirmed = variables.status === "CONFIRMED";
-
 			handleShowToast({
-				message: `모임이 ${isConfirmed ? "확정" : "취소"}되었습니다.`,
+				message: MYPAGE_MESSAGES.patchMeetingStatusSuccess(variables.status),
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.all });
@@ -90,11 +90,9 @@ export function usePatchMeetingsStatus() {
 			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 		},
 
-		onError: (_error, variables) => {
-			const isConfirmed = variables.status === "CONFIRMED";
-
+		onError: (error) => {
 			handleShowToast({
-				message: `모임 ${isConfirmed ? "확정" : "취소"}에 실패했습니다.\n잠시 후 다시 시도해주세요.`,
+				message: error.message,
 				status: "error",
 			});
 		},
@@ -110,7 +108,7 @@ export function useDeleteMeetings() {
 
 		onSuccess: (_data, variables) => {
 			handleShowToast({
-				message: "모임이 삭제 되었습니다.",
+				message: MYPAGE_MESSAGES.deleteMeetingSuccess,
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.all });
@@ -121,9 +119,9 @@ export function useDeleteMeetings() {
 			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: "모임 삭제에 실패했습니다.\n잠시 후 다시 시도해주세요.",
+				message: error.message,
 				status: "error",
 			});
 		},
@@ -140,7 +138,7 @@ export function useDeleteMeetingsJoin() {
 
 		onSuccess: (_data, variables) => {
 			handleShowToast({
-				message: "모임 예약이 취소 되었습니다.",
+				message: MYPAGE_MESSAGES.deleteMeetingJoinSuccess,
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: headerQueryKeys.all });
@@ -154,9 +152,9 @@ export function useDeleteMeetingsJoin() {
 			queryClient.invalidateQueries({ queryKey: meetupQueryKeys.list });
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: "모임 참여 취소에 실패했습니다.\n잠시 후 다시 시도해주세요.",
+				message: error.message,
 				status: "error",
 			});
 		},
@@ -173,16 +171,16 @@ export function usePostMeetingsReviews() {
 
 		onSuccess: () => {
 			handleShowToast({
-				message: `리뷰가 작성 되었습니다.`,
+				message: MYPAGE_MESSAGES.createReviewSuccess,
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.all });
 			queryClient.invalidateQueries({ queryKey: reviewsQueryKeys.reviews.all });
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: `리뷰 작성에 실패했습니다.\n잠시 후 다시 시도해주세요.`,
+				message: error.message,
 				status: "error",
 			});
 		},
@@ -199,16 +197,16 @@ export function usePatchReviews() {
 
 		onSuccess: () => {
 			handleShowToast({
-				message: `리뷰가 수정 되었습니다.`,
+				message: MYPAGE_MESSAGES.updateReviewSuccess,
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.all });
 			queryClient.invalidateQueries({ queryKey: reviewsQueryKeys.reviews.all });
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: `리뷰 수정에 실패했습니다.\n잠시 후 다시 시도해주세요.`,
+				message: error.message,
 				status: "error",
 			});
 		},
@@ -225,16 +223,16 @@ export function useDeleteReviews() {
 
 		onSuccess: () => {
 			handleShowToast({
-				message: `리뷰가 삭제 되었습니다.`,
+				message: MYPAGE_MESSAGES.deleteReviewSuccess,
 				status: "success",
 			});
 			queryClient.invalidateQueries({ queryKey: mypageQueryKeys.all });
 			queryClient.invalidateQueries({ queryKey: reviewsQueryKeys.reviews.all });
 		},
 
-		onError: () => {
+		onError: (error) => {
 			handleShowToast({
-				message: `리뷰 삭제에 실패했습니다.\n잠시 후 다시 시도해주세요.`,
+				message: error.message,
 				status: "error",
 			});
 		},

--- a/features/mypage/mutations.ts
+++ b/features/mypage/mutations.ts
@@ -7,7 +7,6 @@ import {
 	patchReviews,
 	patchUsersMe,
 	postMeetingsReviews,
-	uploadProfileImage,
 } from "./apis";
 import { useToast } from "@/providers/toast-provider";
 import { meetupDetailQueryKeys } from "@/features/shared/queryKeys/meetupDetail";
@@ -16,6 +15,7 @@ import { mypageQueryKeys } from "@/features/shared/queryKeys/mypage";
 import { headerQueryKeys } from "@/features/shared/queryKeys/header";
 import { meetupQueryKeys } from "@/features/shared/queryKeys/meetup";
 import { reviewsQueryKeys } from "@/features/shared/queryKeys/reviews";
+import { uploadImage } from "@/apis/images";
 
 interface UsePatchUsersMeOptions {
 	onSuccessBeforeSync?: () => void;
@@ -24,7 +24,7 @@ interface UsePatchUsersMeOptions {
 export function useUploadProfileImage() {
 	const { handleShowToast } = useToast();
 	return useMutation({
-		mutationFn: uploadProfileImage,
+		mutationFn: uploadImage,
 
 		onSuccess: () => {
 			handleShowToast({

--- a/hooks/useIntersectionObserver.ts
+++ b/hooks/useIntersectionObserver.ts
@@ -1,20 +1,5 @@
 import { useEffect } from "react";
 
-/**
- * 무한 스크롤 시 뷰포트 감지하여 콜백을 실행하는 hook
- *
- * @example
- * const content = useRef<HTMLDivElement>(null);
- *
- * useIntersectionObserver({
- *   targetRef: content,
- *   onIntersect: fetchNextPage,
- *   isEnabled: hasNextPage && !isFetchingNextPage,
- * });
- *
- * return <div ref={content} />;
- */
-
 interface UseIntersectionObserverProps {
 	/** 감시할 DOM 요소의 ref */
 	targetRef: React.RefObject<Element | null>;
@@ -30,6 +15,21 @@ interface UseIntersectionObserverProps {
 	 *  양수면 감지 영역 확장(미리 트리거), 음수면 축소 */
 	rootMargin?: string;
 }
+
+/**
+ * 무한 스크롤 시 뷰포트 감지하여 콜백을 실행하는 hook
+ *
+ * @example
+ * const content = useRef<HTMLDivElement>(null);
+ *
+ * useIntersectionObserver({
+ *   targetRef: content,
+ *   onIntersect: fetchNextPage,
+ *   isEnabled: hasNextPage && !isFetchingNextPage,
+ * });
+ *
+ * return <div ref={content} />;
+ */
 
 export function useIntersectionObserver({
 	targetRef,

--- a/hooks/useMeetingFavorite.ts
+++ b/hooks/useMeetingFavorite.ts
@@ -8,6 +8,11 @@ import { headerQueryKeys } from "@/features/shared/queryKeys/header";
 import { meetupQueryKeys } from "@/features/shared/queryKeys/meetup";
 import { deleteMeetingsFavorite, postMeetingsFavorite } from "@/apis/meetings";
 
+const favoriteQueryPrefixes = [
+	mypageQueryKeys.meetups.all,
+	mypageQueryKeys.reviews.available,
+] as const;
+
 /**
  * 찜 추가 시 낙관적 업데이트 및 롤백 하는 훅
  *
@@ -15,11 +20,6 @@ import { deleteMeetingsFavorite, postMeetingsFavorite } from "@/apis/meetings";
  * const { handleWishToggle } = useMeetingFavorite();
  * handleWishToggle(item.id, item.isFavorited)
  */
-
-const favoriteQueryPrefixes = [
-	mypageQueryKeys.meetups.all,
-	mypageQueryKeys.reviews.available,
-] as const;
 
 export default function useMeetingFavorite() {
 	const queryClient = useQueryClient();

--- a/hooks/useMeetingFavorite.ts
+++ b/hooks/useMeetingFavorite.ts
@@ -2,11 +2,11 @@
 
 import { CursorPageResponse, MeetupList } from "@/features/mypage/types";
 import { InfiniteData, useMutation, useQueryClient } from "@tanstack/react-query";
-import { deleteMeetingsFavorites, postMeetingsFavorites } from "@/features/mypage/apis";
 import { meetupDetailQueryKeys } from "@/features/shared/queryKeys/meetupDetail";
 import { mypageQueryKeys } from "@/features/shared/queryKeys/mypage";
 import { headerQueryKeys } from "@/features/shared/queryKeys/header";
 import { meetupQueryKeys } from "@/features/shared/queryKeys/meetup";
+import { deleteMeetingsFavorite, postMeetingsFavorite } from "@/apis/meetings";
 
 /**
  * 찜 추가 시 낙관적 업데이트 및 롤백 하는 훅
@@ -26,7 +26,7 @@ export default function useMeetingFavorite() {
 
 	const { mutate } = useMutation({
 		mutationFn: ({ meetingId, currentState }: { meetingId: number; currentState: boolean }) =>
-			currentState ? deleteMeetingsFavorites(meetingId) : postMeetingsFavorites(meetingId),
+			currentState ? deleteMeetingsFavorite({ meetingId }) : postMeetingsFavorite({ meetingId }),
 
 		// API 호출 전에 실행
 		onMutate: async ({ meetingId }) => {

--- a/hooks/useScrollVisibility.ts
+++ b/hooks/useScrollVisibility.ts
@@ -1,6 +1,10 @@
 "use client";
 
 import { RefObject, useEffect, useState } from "react";
+interface UseScrollVisibilityProps {
+	threshold?: number;
+	targetRef?: RefObject<HTMLElement | null>;
+}
 
 /**
  * 스크롤 위치에 따라 요소 노출 여부를 제어
@@ -17,11 +21,6 @@ import { RefObject, useEffect, useState } from "react";
  *   targetRef: contentRef,
  * });
  */
-
-interface UseScrollVisibilityProps {
-	threshold?: number;
-	targetRef?: RefObject<HTMLElement | null>;
-}
 
 export default function useScrollVisibility({
 	threshold = 100,

--- a/utils/api.test.ts
+++ b/utils/api.test.ts
@@ -92,6 +92,33 @@ describe("utils/api", () => {
 				}
 			});
 
+			test("statusMessages에 해당 status가 있으면 응답 바디 message보다 우선한다", async () => {
+				const res = createMockResponse({
+					ok: false,
+					status: 404,
+					json: jest.fn().mockResolvedValue({
+						code: "NOT_FOUND",
+						message: "모임 없음",
+					}),
+				});
+
+				try {
+					await throwApiError(res, "모임 삭제에 실패했습니다.", {
+						statusMessages: {
+							404: "이미 삭제된 모임입니다.",
+						},
+					});
+				} catch (error) {
+					expect(error).toBeInstanceOf(ApiError);
+					expect(error).toMatchObject({
+						message: "이미 삭제된 모임입니다.",
+						status: 404,
+						code: "NOT_FOUND",
+						fallbackMessage: "모임 삭제에 실패했습니다.",
+					});
+				}
+			});
+
 			test("JSON 파싱에 실패하면 fallbackMessage로 ApiError를 던진다", async () => {
 				const res = createMockResponse({
 					ok: false,

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -5,6 +5,21 @@ interface ApiErrorParams {
 	fallbackMessage?: string;
 }
 
+// 기본 Error를 확장한 커스텀 에러 클래스
+export class ApiError extends Error {
+	status: number; // HTTP 상태코드
+	code?: string; // 백엔드가 내려주는 에러 코드
+	fallbackMessage?: string; // 폴백용 기본메세지
+
+	constructor({ message, status, code, fallbackMessage }: ApiErrorParams) {
+		super(message); // Error 호출
+		this.name = "ApiError"; // 디버깅 용이하도록 이름 명시
+		this.status = status;
+		this.code = code;
+		this.fallbackMessage = fallbackMessage;
+	}
+}
+
 /**
  * API 응답이 실패한 경우 에러 바디의 message를 우선 읽어 throw합니다
  *
@@ -32,22 +47,6 @@ interface ApiErrorParams {
  *  });
  * }
  */
-
-// 기본 Error를 확장한 커스텀 에러 클래스
-export class ApiError extends Error {
-	status: number; // HTTP 상태코드
-	code?: string; // 백엔드가 내려주는 에러 코드
-	fallbackMessage?: string; // 폴백용 기본메세지
-
-	constructor({ message, status, code, fallbackMessage }: ApiErrorParams) {
-		super(message); // Error 호출
-		this.name = "ApiError"; // 디버깅 용이하도록 이름 명시
-		this.status = status;
-		this.code = code;
-		this.fallbackMessage = fallbackMessage;
-	}
-}
-
 export async function throwApiError(response: Response, fallbackMessage: string): Promise<void> {
 	if (response.ok) return;
 

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -5,6 +5,10 @@ interface ApiErrorParams {
 	fallbackMessage?: string;
 }
 
+interface ThrowApiErrorOptions {
+	statusMessages?: Partial<Record<number, string>>;
+}
+
 // 기본 Error를 확장한 커스텀 에러 클래스
 export class ApiError extends Error {
 	status: number; // HTTP 상태코드
@@ -27,19 +31,22 @@ export class ApiError extends Error {
  *
  * @param response fetch response 객체
  * @param fallbackMessage 응답 바디를 읽을 수 없을 때 사용할 기본 에러 메시지
+ * @param options 특정 HTTP status에 대해 서버 message보다 우선 사용할 메시지 옵션
  * @throws {ApiError} API 실패 응답의 메시지, 상태코드, 에러코드를 담은 에러
  *
  * @example
- * const res = await clientFetch("/users/me", {
- *   method: "PATCH",
- *   body: JSON.stringify(payload),
- * });
+ * const res = await clientFetch(...);
  *
- * await throwApiError(res, "프로필 수정에 실패했습니다.");
+ * await throwApiError(res, "모임 삭제에 실패했습니다.", {
+ *   statusMessages: {
+ *     404: "이미 삭제된 모임입니다.",
+ *   },
+ * });
  * return res.json();
  *
- * 1. 서버가 message 내려주면 그 문구 노출
- * 2. 서버 message 없으면 throwApiError에 넣은 폴백 문구 노출
+ * 1. statusMessages에 해당 status가 있으면 그 문구 노출
+ * 2. 서버가 message 내려주면 그 문구 노출
+ * 3. 서버 message 없으면 throwApiError에 넣은 폴백 문구 노출
  * onError: (error: Error) => {
  *  handleShowToast({
  *   message: error.message,
@@ -47,14 +54,19 @@ export class ApiError extends Error {
  *  });
  * }
  */
-export async function throwApiError(response: Response, fallbackMessage: string): Promise<void> {
+export async function throwApiError(
+	response: Response,
+	fallbackMessage: string,
+	options: ThrowApiErrorOptions = {},
+): Promise<void> {
 	if (response.ok) return;
 
 	// 응답 실패시 null
 	const data = await response.json().catch(() => null);
+	const statusMessage = options.statusMessages?.[response.status];
 
 	throw new ApiError({
-		message: data?.message ?? fallbackMessage,
+		message: statusMessage ?? data?.message ?? fallbackMessage,
 		status: response.status,
 		code: data?.code,
 		fallbackMessage,

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -22,6 +22,15 @@ interface ApiErrorParams {
  *
  * await throwApiError(res, "프로필 수정에 실패했습니다.");
  * return res.json();
+ *
+ * 1. 서버가 message 내려주면 그 문구 노출
+ * 2. 서버 message 없으면 throwApiError에 넣은 폴백 문구 노출
+ * onError: (error: Error) => {
+ *  handleShowToast({
+ *   message: error.message,
+ *   status: "error",
+ *  });
+ * }
  */
 
 // 기본 Error를 확장한 커스텀 에러 클래스
@@ -53,6 +62,35 @@ export async function throwApiError(response: Response, fallbackMessage: string)
 	});
 }
 
+/**
+ * 사용자에게 보여줄 에러 메시지를 안전하게 추출합니다.
+ *
+ * throwApiError를 사용한 API 에러 처리 외에도
+ * throwApiError를 사용하지 않았거나 에러 형태가 일정하지 않을 때 사용할 수 있습니다.
+ *
+ * @param error onError 등에서 전달받은 알 수 없는 에러 객체
+ * @param fallback error에서 메시지를 꺼낼 수 없을 때 사용할 기본 문구
+ *
+ *
+ * @example
+ * 일반 Error를 직접 throw한 경우
+ * try {
+ *   throw new Error("이미지 업로드에 실패했습니다.");
+ * } catch (error) {
+ *   const message = getUserErrorMessage(error, "알 수 없는 오류가 발생했습니다.");
+ * }
+ *
+ * @example
+ * 문자열이나 예상치 못한 값이 넘어온 경우 fallback 사용
+ * const message = getUserErrorMessage("network error", "잠시 후 다시 시도해주세요.");
+ */
+export function getUserErrorMessage(error: unknown, fallback: string) {
+	if (error instanceof Error) {
+		return error.message || fallback;
+	}
+	return fallback;
+}
+
 // 백엔드 응답이 비어 있거나 JSON이 아닐 수 있어 안전하게 파싱
 export async function parseJsonSafely(response: Response) {
 	try {
@@ -60,11 +98,4 @@ export async function parseJsonSafely(response: Response) {
 	} catch {
 		return null;
 	}
-}
-
-export function getUserErrorMessage(error: unknown, fallback: string) {
-	if (error instanceof Error) {
-		return error.message || fallback;
-	}
-	return fallback;
 }


### PR DESCRIPTION
## 🛠️ 설명 (Description)

마이페이지 api 에러처리 및 에러 메세지 노출 방식을 일관성 있도록 변경하고 
scroll 시 탭 영역으로 강제이동 되는 이슈 수정

## 📝 변경 사항 요약 (Summary)

- utils/api.ts : status 별 에러메세지를 커스텀 할 수 있도록 확장
- mypage/TabWrapper: scroll 시 탭 영역으로 강제이동 되는 이슈 수정 및 트러블슈팅 노션작성
- 주석 위치 변경하여 함수에 jsdoc 이 출력되도록 변경

## 💁 변경 사항 이유 (Why)

- utils/api.ts에서 options 추가한 이유는 백엔드에서 전달해준 에러값을 그대로 사용 하되 일부 코드만 커스텀 메세지를 출력하고 싶을때 사용하기 위함 

## ✅ 테스트 계획 (Test Plan)

- api.test.ts 에서 유닛테스트 통과완료 했습니다.
- 관련 테스트는 `statusMessages에 해당 status가 있으면 응답 바디 message보다 우선한다` 항목입니다.
## 🔗 관련 이슈 (Related Issues)

- Closed #295 
- Related #이슈번호

## ☑️ 체크리스트 (Checklist)

- [x] 코드가 프로젝트 코딩 컨벤션을 따릅니다.
- [x] 테스트 코드가 작성되었고, 통과했습니다.
- [x] 변경 사항에 대한 문서화가 완료되었습니다.
- [ ] 필요한 경우, 다른 팀원에게 리뷰를 요청했습니다.
- [x] CI/CD 파이프라인이 성공했습니다.

## 👀 리뷰어를 위한 참고 사항 (Notes for Reviewers)

## ➕ 추가 정보 (Additional Information)
